### PR TITLE
docs(README): fix typos

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 yarn commitlint -c --config .commitlintrc.json -E --edit

--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@
 </div>
 
 ## Introduction
+
 **NestJS tRPC** is a library designed to integrate the capabilities of tRPC into the NestJS framework. It aims to provide native support for decorators and implement an opinionated approach that aligns with NestJS conventions.
 
 ## Features
+
 - ✅&nbsp; Supports most tRPC features out of the box with more to come.
 - 🧙‍&nbsp; Full static typesafety & autocompletion on the client, for inputs, outputs, and errors.
 - 🙀&nbsp; Implements the Nestjs opinionated approach to how tRPC works.
@@ -33,20 +35,22 @@
 ## Quickstart
 
 ### Installation
+
 To install **NestJS tRPC** with your preferred package manager, you can use any of the following commands:
 
 ```shell
 # npm
-npm install trpc-nestjs
+npm install trpc-nestjs zod
 
 # pnpm
-pnpm add trpc-nestjs
+pnpm add trpc-nestjs zod
 
 # yarn
-yarn add trpc-nestjs
+yarn add trpc-nestjs zod
 ```
 
 ## How to use
+
 Here's a brief example demonstrating how to use the decorators available in **NestJS tRPC**:
 
 ```typescript
@@ -54,6 +58,7 @@ Here's a brief example demonstrating how to use the decorators available in **Ne
 import { Router, Query, Procedure } from 'trpc-nestjs';
 import { UserService } from './user.service';
 import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
 
 const userSchema = z.object({
   name: z.string(),
@@ -63,18 +68,16 @@ const userSchema = z.object({
 @Router()
 class UserRouter {
   constructor(
-    @Inject(UserService) private readonly userService: UserService
-  ) {
-  }
+    private readonly userService: UserService
+  ) {}
 
   @Procedure(ProtectedProcedure)
   @Query({ output: z.array(userSchema) })
   async getUsers() {
     try {
-      const users = await this.userService.getUsers();
-      return users;
-    } catch (e: unknown) {
-      throw new TRPCError("An error has occured when trying to get users.", "INTERNAL_SERVER_ERROR", e)
+      return this.userService.getUsers();
+    } catch (error: unknown) {
+      throw new TRPCError("An error has occured when trying to get users.", "INTERNAL_SERVER_ERROR", error)
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </div>
 
 ## Introduction
-**NestJS RPC** is a library designed to integrate the capabilities of tRPC into the NestJS framework. It aims to provide native support for decorators and implement an opinionated approach that aligns with NestJS conventions.
+**NestJS tRPC** is a library designed to integrate the capabilities of tRPC into the NestJS framework. It aims to provide native support for decorators and implement an opinionated approach that aligns with NestJS conventions.
 
 ## Features
 - ✅&nbsp; Supports most tRPC features out of the box with more to come.
@@ -84,7 +84,7 @@ class UserRouter {
 
 ## All contributors
 
-> tRPC is developed by [Kevin Edry](https://twitter.com/KevinEdry), which taken a huge inspiration from both NestJS and tRPC inner workings.
+> NestJS tRPC is developed by [Kevin Edry](https://twitter.com/KevinEdry), which taken a huge inspiration from both NestJS and tRPC inner workings.
 
 <a href="https://github.com/KevinEdry/nestjs-trpc/graphs/contributors">
   <p align="center">

--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ To install **NestJS tRPC** with your preferred package manager, you can use any 
 
 ```shell
 # npm
-npm install trpc-nestjs zod
+npm install trpc-nestjs zod @trpc/server
 
 # pnpm
-pnpm add trpc-nestjs zod
+pnpm add trpc-nestjs zod @trpc/server
 
 # yarn
-yarn add trpc-nestjs zod
+yarn add trpc-nestjs zod @trpc/server
 ```
 
 ## How to use
@@ -55,8 +55,10 @@ Here's a brief example demonstrating how to use the decorators available in **Ne
 
 ```typescript
 // users.router.ts
-import { Router, Query, Procedure } from 'trpc-nestjs';
+import { Inject } from '@nestjs/common';
+import { Router, Query, Middlewares } from 'trpc-nestjs';
 import { UserService } from './user.service';
+import { ProtectedMiddleware } from './protected.middleware';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
@@ -68,16 +70,20 @@ const userSchema = z.object({
 @Router()
 class UserRouter {
   constructor(
-    private readonly userService: UserService
+    @Inject(UserService) private readonly userService: UserService
   ) {}
 
-  @Procedure(ProtectedProcedure)
+  @Middlewares(ProtectedMiddleware)
   @Query({ output: z.array(userSchema) })
   async getUsers() {
     try {
       return this.userService.getUsers();
     } catch (error: unknown) {
-      throw new TRPCError("An error has occured when trying to get users.", "INTERNAL_SERVER_ERROR", error)
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "An error has occured when trying to get users.",
+        cause: error
+      })
     }
   }
 }


### PR DESCRIPTION
Fixing simple typos inside `README.md`

Also I'm suggesting to embed a gif that really uses `nestjs-trpc` and not vanilla trpc server.