### PR TITLE
[Feature] Expose AppRouter

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,0 @@
-packages/**/tests/**
-dist
-node_modules
-.pnp.cjs
-.pnp.loader.mjs

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -11556,6 +11556,7 @@ const RAW_RUNTIME_STATE =
           ["nestjs-trpc", "virtual:1d5ebb853d503e6fea373f31bf5c65a3d6b7a77f545a96c962e755e47337c3e496ed5cee7282e41167a1f4dfa23fb3acbbefc04d81bed7ec8f8b7c619015ae65#workspace:packages/nestjs-trpc"],\
           ["reflect-metadata", "npm:0.1.14"],\
           ["rxjs", "npm:7.8.1"],\
+          ["trpc-panel", "virtual:1d5ebb853d503e6fea373f31bf5c65a3d6b7a77f545a96c962e755e47337c3e496ed5cee7282e41167a1f4dfa23fb3acbbefc04d81bed7ec8f8b7c619015ae65#npm:1.3.4"],\
           ["ts-morph", "npm:23.0.0"],\
           ["ts-node", "virtual:1d5ebb853d503e6fea373f31bf5c65a3d6b7a77f545a96c962e755e47337c3e496ed5cee7282e41167a1f4dfa23fb3acbbefc04d81bed7ec8f8b7c619015ae65#npm:10.9.2"],\
           ["tsconfig-paths", "npm:4.2.0"],\
@@ -12332,6 +12333,15 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../../.yarn/berry/cache/functions-have-names-npm-1.2.3-e5cf1e2208-10c0.zip/node_modules/functions-have-names/",\
         "packageDependencies": [\
           ["functions-have-names", "npm:1.2.3"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["fuzzysort", [\
+      ["npm:2.0.4", {\
+        "packageLocation": "../../.yarn/berry/cache/fuzzysort-npm-2.0.4-e5d0285b2d-10c0.zip/node_modules/fuzzysort/",\
+        "packageDependencies": [\
+          ["fuzzysort", "npm:2.0.4"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -13346,6 +13356,13 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["inherits", [\
+      ["npm:2.0.3", {\
+        "packageLocation": "../../.yarn/berry/cache/inherits-npm-2.0.3-401e64b080-10c0.zip/node_modules/inherits/",\
+        "packageDependencies": [\
+          ["inherits", "npm:2.0.3"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["npm:2.0.4", {\
         "packageLocation": "../../.yarn/berry/cache/inherits-npm-2.0.4-c66b3957a0-10c0.zip/node_modules/inherits/",\
         "packageDependencies": [\
@@ -18295,6 +18312,17 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["path", [\
+      ["npm:0.12.7", {\
+        "packageLocation": "../../.yarn/berry/cache/path-npm-0.12.7-bddabe2e86-10c0.zip/node_modules/path/",\
+        "packageDependencies": [\
+          ["path", "npm:0.12.7"],\
+          ["process", "npm:0.11.10"],\
+          ["util", "npm:0.10.4"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["path-browserify", [\
       ["npm:1.0.1", {\
         "packageLocation": "../../.yarn/berry/cache/path-browserify-npm-1.0.1-f975d99a99-10c0.zip/node_modules/path-browserify/",\
@@ -18762,6 +18790,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["process", [\
+      ["npm:0.11.10", {\
+        "packageLocation": "../../.yarn/berry/cache/process-npm-0.11.10-aeb3b641ae-10c0.zip/node_modules/process/",\
+        "packageDependencies": [\
+          ["process", "npm:0.11.10"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["process-nextick-args", [\
       ["npm:2.0.1", {\
         "packageLocation": "../../.yarn/berry/cache/process-nextick-args-npm-2.0.1-b8d7971609-10c0.zip/node_modules/process-nextick-args/",\
@@ -18905,6 +18942,13 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["punycode", [\
+      ["npm:1.4.1", {\
+        "packageLocation": "../../.yarn/berry/cache/punycode-npm-1.4.1-be4c23e6d2-10c0.zip/node_modules/punycode/",\
+        "packageDependencies": [\
+          ["punycode", "npm:1.4.1"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["npm:2.3.1", {\
         "packageLocation": "../../.yarn/berry/cache/punycode-npm-2.3.1-97543c420d-10c0.zip/node_modules/punycode/",\
         "packageDependencies": [\
@@ -18937,6 +18981,14 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../../.yarn/berry/cache/qs-npm-6.11.0-caf1bc9dea-10c0.zip/node_modules/qs/",\
         "packageDependencies": [\
           ["qs", "npm:6.11.0"],\
+          ["side-channel", "npm:1.0.6"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:6.13.0", {\
+        "packageLocation": "../../.yarn/berry/cache/qs-npm-6.13.0-53676ddc84-10c0.zip/node_modules/qs/",\
+        "packageDependencies": [\
+          ["qs", "npm:6.13.0"],\
           ["side-channel", "npm:1.0.6"]\
         ],\
         "linkType": "HARD"\
@@ -21190,6 +21242,36 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["trpc-panel", [\
+      ["npm:1.3.4", {\
+        "packageLocation": "../../.yarn/berry/cache/trpc-panel-npm-1.3.4-5c1e0b2831-10c0.zip/node_modules/trpc-panel/",\
+        "packageDependencies": [\
+          ["trpc-panel", "npm:1.3.4"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:1d5ebb853d503e6fea373f31bf5c65a3d6b7a77f545a96c962e755e47337c3e496ed5cee7282e41167a1f4dfa23fb3acbbefc04d81bed7ec8f8b7c619015ae65#npm:1.3.4", {\
+        "packageLocation": "./.yarn/__virtual__/trpc-panel-virtual-a38c8e7fda/3/.yarn/berry/cache/trpc-panel-npm-1.3.4-5c1e0b2831-10c0.zip/node_modules/trpc-panel/",\
+        "packageDependencies": [\
+          ["trpc-panel", "virtual:1d5ebb853d503e6fea373f31bf5c65a3d6b7a77f545a96c962e755e47337c3e496ed5cee7282e41167a1f4dfa23fb3acbbefc04d81bed7ec8f8b7c619015ae65#npm:1.3.4"],\
+          ["@trpc/server", "npm:10.45.2"],\
+          ["@types/trpc__server", null],\
+          ["@types/zod", null],\
+          ["fuzzysort", "npm:2.0.4"],\
+          ["path", "npm:0.12.7"],\
+          ["url", "npm:0.11.4"],\
+          ["zod", "npm:3.23.8"],\
+          ["zod-to-json-schema", "virtual:a38c8e7fda3ec3654af6346b14e1b214a95483cd323b7022753c84aa661565ec4a3c80e5029f292dd5015b38f4e560c790ca5b26703020ef164c6954eb5ee5a1#npm:3.23.3"]\
+        ],\
+        "packagePeers": [\
+          "@trpc/server",\
+          "@types/trpc__server",\
+          "@types/zod",\
+          "zod"\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["ts-api-utils", [\
       ["npm:1.3.0", {\
         "packageLocation": "../../.yarn/berry/cache/ts-api-utils-npm-1.3.0-33457908f8-10c0.zip/node_modules/ts-api-utils/",\
@@ -22085,6 +22167,17 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["url", [\
+      ["npm:0.11.4", {\
+        "packageLocation": "../../.yarn/berry/cache/url-npm-0.11.4-706538be7c-10c0.zip/node_modules/url/",\
+        "packageDependencies": [\
+          ["url", "npm:0.11.4"],\
+          ["punycode", "npm:1.4.1"],\
+          ["qs", "npm:6.13.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["url-join", [\
       ["npm:4.0.1", {\
         "packageLocation": "../../.yarn/berry/cache/url-join-npm-4.0.1-e1f4415722-10c0.zip/node_modules/url-join/",\
@@ -22097,6 +22190,16 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../../.yarn/berry/cache/url-join-npm-5.0.0-27d329c4cf-10c0.zip/node_modules/url-join/",\
         "packageDependencies": [\
           ["url-join", "npm:5.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["util", [\
+      ["npm:0.10.4", {\
+        "packageLocation": "../../.yarn/berry/cache/util-npm-0.10.4-7c577db41a-10c0.zip/node_modules/util/",\
+        "packageDependencies": [\
+          ["util", "npm:0.10.4"],\
+          ["inherits", "npm:2.0.3"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -22899,6 +23002,28 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../../.yarn/berry/cache/zod-npm-3.23.8-11c49c85b5-10c0.zip/node_modules/zod/",\
         "packageDependencies": [\
           ["zod", "npm:3.23.8"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["zod-to-json-schema", [\
+      ["npm:3.23.3", {\
+        "packageLocation": "../../.yarn/berry/cache/zod-to-json-schema-npm-3.23.3-86415b1ed5-10c0.zip/node_modules/zod-to-json-schema/",\
+        "packageDependencies": [\
+          ["zod-to-json-schema", "npm:3.23.3"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:a38c8e7fda3ec3654af6346b14e1b214a95483cd323b7022753c84aa661565ec4a3c80e5029f292dd5015b38f4e560c790ca5b26703020ef164c6954eb5ee5a1#npm:3.23.3", {\
+        "packageLocation": "./.yarn/__virtual__/zod-to-json-schema-virtual-87152f83f0/3/.yarn/berry/cache/zod-to-json-schema-npm-3.23.3-86415b1ed5-10c0.zip/node_modules/zod-to-json-schema/",\
+        "packageDependencies": [\
+          ["zod-to-json-schema", "virtual:a38c8e7fda3ec3654af6346b14e1b214a95483cd323b7022753c84aa661565ec4a3c80e5029f292dd5015b38f4e560c790ca5b26703020ef164c6954eb5ee5a1#npm:3.23.3"],\
+          ["@types/zod", null],\
+          ["zod", "npm:3.23.8"]\
+        ],\
+        "packagePeers": [\
+          "@types/zod",\
+          "zod"\
         ],\
         "linkType": "HARD"\
       }]\

--- a/docs/pages/docs/_meta.json
+++ b/docs/pages/docs/_meta.json
@@ -26,6 +26,7 @@
   "context": "Context",
   "dependency-injection": "Dependency Injection",
   "client": "Client Usage",
+  "integrations": "Integrations",
 
   "-- appendix": {
     "type": "separator",

--- a/docs/pages/docs/integrations.mdx
+++ b/docs/pages/docs/integrations.mdx
@@ -1,0 +1,104 @@
+---
+title: "Integrations"
+---
+
+import { Callout, Steps, Tabs } from 'nextra-theme-docs';
+
+# Integrations
+
+### Accessing the AppRouter
+In some circumstances ,for example end-to-end tests or integrating with other `trpc` plugins, you may want to get a reference to the generated appRouter object. In end-to-end tests, you can then run queries using the appRouter object directly without using any HTTP listeners.
+
+You can access the generated appRouter using the `AppRouterHost` class:
+
+```typescript
+const { appRouter } = app.get(AppRouterHost);
+```
+<Callout>
+You must call the `AppRouterHost.appRouter{:tsx}` getter after the application has been initialized (after the `onModuleInit` hook has been triggered by either the `app.listen(){:tsx}` or `app.init(){:tsx}` method).
+</Callout>
+
+With the runtime appRouter object, you can integrate with virtually any trpc-specific library, this includes [trpc-panel](https://github.com/iway1/trpc-panel), [trpc-openapi](https://github.com/jlalmes/trpc-openapi), [trpc-playground](https://github.com/sachinraja/trpc-playground) and more.
+
+### Integrating with `trpc-panel`
+Here is a short example of how to integrate [trpc-panel](https://github.com/iway1/trpc-panel), while this is a specific integration, the techniques used here can be applied to any of the trpc-specific libraries you wish to include. <br/>
+If you still run into issues, please open a [new issue](https://github.com/KevinEdry/nestjs-trpc/issues/new) or contact us via Discord.
+
+<Steps>
+  ### Installation
+  To install `trpc-panel` with your preferred package manager, you can use any of the following commands:
+  <Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
+    <Tabs.Tab>
+      ```bash copy
+      npm install trpc-panel
+      ```
+    </Tabs.Tab>
+    <Tabs.Tab>
+      ```bash copy
+      pnpm add trpc-panel
+      ```
+    </Tabs.Tab>
+    <Tabs.Tab>
+      ```bash copy
+      yarn add trpc-panel
+      ```
+     </Tabs.Tab>
+    <Tabs.Tab>
+      ```bash copy
+      bun install trpc-panel
+      ```
+     </Tabs.Tab>
+  </Tabs>
+
+  ### Creating the Panel Controller
+  As per the `trpc-panel` [docs](https://github.com/iway1/trpc-panel?tab=readme-ov-file#quick-start) we need to serve the panel, using the `renderTrpcPanel` method for every method on route `/panel`.
+
+  ```typescript {8, 14-16} filename="trpc-panel.controller.ts" copy
+  import { All, Controller, Inject, OnModuleInit } from '@nestjs/common';
+  import { renderTrpcPanel } from 'trpc-panel';
+  import { AnyRouter } from '@trpc/server';
+  import { AppRouterHost } from 'nestjs-trpc';
+
+  @Controller()
+  export class TrpcPanelController implements OnModuleInit {
+    private appRouter!: AnyRouter;
+
+    constructor(
+      @Inject(AppRouterHost) private readonly appRouterHost: AppRouterHost,
+    ) {}
+
+    onModuleInit() {
+      this.appRouter = this.appRouterHost.appRouter;
+    }
+
+    @All('/panel')
+    panel(): string {
+      return renderTrpcPanel(this.appRouter, {
+        url: 'http://localhost:8080/trpc',
+      });
+    }
+  }
+  ```
+  <Callout>
+    As you can see in the example above, we are using `onModuleInit` lifecycle method to make sure the appRouter is initialized and available.
+  </Callout>
+
+  ### Register the Controller
+  In order to apply the new Controller routes, we need to register it in the `app.module.ts` file.
+
+  ```typescript /TrpcPanelController/ filename="app.module.ts" copy
+  @Module({
+    imports: [
+      TRPCModule.forRoot({
+        autoSchemaFile: './src/@generated',
+        context: AppContext,
+      }),
+    ],
+    controllers: [TrpcPanelController],
+    providers: [],
+  })
+  export class AppModule {}
+  ```
+</Steps>
+
+After you register the controller, you can run your NestJS app, and `trpc-panel` should be acceptable from https://localhost:8080/panel.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,7 +15,14 @@ const compat = new FlatCompat({
 });
 
 export default [{
-    ignores: ["wpackages/**/tests/**/*"],
+    ignores: [
+        "packages/**/tests/**",
+        "examples",
+        "dist",
+        "node_modules",
+        ".pnp.cjs",
+        ".pnp.loader.mjs"
+    ],
 }, ...compat.extends(
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",

--- a/examples/nestjs-express/package.json
+++ b/examples/nestjs-express/package.json
@@ -33,6 +33,7 @@
     "@types/express": "^4.17.17",
     "@types/node": "^22.5.0",
     "chokidar": "^3.6.0",
+    "trpc-panel": "^1.3.4",
     "ts-morph": "^23.0.0",
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.2.0",

--- a/examples/nestjs-express/src/app.module.ts
+++ b/examples/nestjs-express/src/app.module.ts
@@ -4,6 +4,7 @@ import { TRPCModule } from 'nestjs-trpc';
 import { UserService } from './user.service';
 import { ProtectedMiddleware } from './protected.middleware';
 import { AppContext } from './app.context';
+import { TrpcPanelController } from './trpc-panel.controller';
 
 @Module({
   imports: [
@@ -12,6 +13,7 @@ import { AppContext } from './app.context';
       context: AppContext,
     }),
   ],
+  controllers: [TrpcPanelController],
   providers: [UserRouter, AppContext, UserService, ProtectedMiddleware],
 })
 export class AppModule {}

--- a/examples/nestjs-express/src/trpc-panel.controller.ts
+++ b/examples/nestjs-express/src/trpc-panel.controller.ts
@@ -1,0 +1,24 @@
+import { All, Controller, Inject, OnModuleInit } from '@nestjs/common';
+import { renderTrpcPanel } from 'trpc-panel';
+import { AnyRouter } from '@trpc/server';
+import { AppRouterHost } from 'nestjs-trpc';
+
+@Controller()
+export class TrpcPanelController implements OnModuleInit {
+  private appRouter!: AnyRouter;
+
+  constructor(
+    @Inject(AppRouterHost) private readonly appRouterHost: AppRouterHost,
+  ) {}
+
+  onModuleInit() {
+    this.appRouter = this.appRouterHost.appRouter;
+  }
+
+  @All('/panel')
+  panel(): string {
+    return renderTrpcPanel(this.appRouter, {
+      url: 'http://localhost:8080/trpc',
+    });
+  }
+}

--- a/packages/nestjs-trpc/lib/app-router.host.ts
+++ b/packages/nestjs-trpc/lib/app-router.host.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { AnyRouter } from '@trpc/server';
+
+@Injectable()
+export class AppRouterHost {
+  private _appRouter: AnyRouter | undefined;
+
+  set appRouter(schemaRef: AnyRouter) {
+    this._appRouter = schemaRef;
+  }
+
+  get appRouter(): AnyRouter {
+    if (!this._appRouter) {
+      throw new Error(
+        'TRPC appRouter has not yet been created. ' +
+          'Make sure to call the "AppRouterHost#appRouter" getter when the application is already initialized (after the "onModuleInit" hook triggered by either "app.listen()" or "app.init()" method).',
+      );
+    }
+    return this._appRouter;
+  }
+}

--- a/packages/nestjs-trpc/lib/index.ts
+++ b/packages/nestjs-trpc/lib/index.ts
@@ -1,3 +1,4 @@
 export * from './trpc.module';
 export * from './interfaces';
 export * from './decorators';
+export * from './app-router.host';

--- a/packages/nestjs-trpc/lib/trpc.driver.ts
+++ b/packages/nestjs-trpc/lib/trpc.driver.ts
@@ -1,12 +1,12 @@
 import { ConsoleLogger, Inject, Injectable, Type } from '@nestjs/common';
-import { ApplicationConfig, HttpAdapterHost, ModuleRef } from '@nestjs/core';
+import { HttpAdapterHost, ModuleRef } from '@nestjs/core';
 import type { Application as ExpressApplication } from 'express';
 import { TRPCContext, TRPCModuleOptions } from './interfaces';
 import { AnyRouter, initTRPC } from '@trpc/server';
 import * as trpcExpress from '@trpc/server/adapters/express';
 import { TRPCFactory } from './factories/trpc.factory';
 import { TRPCGenerator } from './generators/trpc.generator';
-import { Class } from 'type-fest';
+import { AppRouterHost } from './app-router.host';
 
 @Injectable()
 export class TRPCDriver<
@@ -23,6 +23,9 @@ export class TRPCDriver<
 
   @Inject(ConsoleLogger)
   protected readonly consoleLogger!: ConsoleLogger;
+
+  @Inject(AppRouterHost)
+  protected readonly appRouterHost!: AppRouterHost;
 
   constructor(private moduleRef: ModuleRef) {}
 
@@ -49,6 +52,8 @@ export class TRPCDriver<
       router,
       procedure,
     );
+
+    this.appRouterHost.appRouter = appRouter;
 
     const contextClass = options.context;
     const contextInstance =

--- a/packages/nestjs-trpc/lib/trpc.module.ts
+++ b/packages/nestjs-trpc/lib/trpc.module.ts
@@ -18,6 +18,7 @@ import { DecoratorGenerator } from './generators/decorator.generator';
 import { RouterGenerator } from './generators/router.generator';
 import { MiddlewareGenerator } from './generators/middleware.generator';
 import { ContextGenerator } from './generators/context.generator';
+import { AppRouterHost } from './app-router.host';
 
 @Module({
   imports: [],
@@ -34,8 +35,9 @@ import { ContextGenerator } from './generators/context.generator';
     ContextGenerator,
     RouterGenerator,
     TRPCGenerator,
+    AppRouterHost,
   ],
-  exports: [],
+  exports: [AppRouterHost],
 })
 export class TRPCModule implements OnModuleInit {
   @Inject(TRPC_MODULE_OPTIONS)
@@ -49,6 +51,9 @@ export class TRPCModule implements OnModuleInit {
 
   @Inject(TRPCDriver)
   private readonly trpcDriver!: TRPCDriver;
+
+  @Inject(AppRouterHost)
+  private readonly appRouterHost!: AppRouterHost;
 
   static forRoot<TOptions extends Record<string, any> = TRPCModuleOptions>(
     options: TOptions = {} as TOptions,
@@ -67,9 +72,12 @@ export class TRPCModule implements OnModuleInit {
 
     this.consoleLogger.setContext(LOGGER_CONTEXT);
     await this.trpcDriver.start(this.options);
-    this.consoleLogger.log(
-      'Server has been initialized successfully.',
-      'TRPC Server',
-    );
+
+    if (this.appRouterHost.appRouter != null) {
+      this.consoleLogger.log(
+        'Server has been initialized successfully.',
+        'TRPC Server',
+      );
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8237,6 +8237,7 @@ __metadata:
     nestjs-trpc: "workspace:*"
     reflect-metadata: "npm:^0.1.13"
     rxjs: "npm:^7.2.0"
+    trpc-panel: "npm:^1.3.4"
     ts-morph: "npm:^23.0.0"
     ts-node: "npm:^10.9.1"
     tsconfig-paths: "npm:^4.2.0"
@@ -8921,6 +8922,13 @@ __metadata:
   version: 1.2.3
   resolution: "functions-have-names@npm:1.2.3"
   checksum: 10c0/33e77fd29bddc2d9bb78ab3eb854c165909201f88c75faa8272e35899e2d35a8a642a15e7420ef945e1f64a9670d6aa3ec744106b2aa42be68ca5114025954ca
+  languageName: node
+  linkType: hard
+
+"fuzzysort@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "fuzzysort@npm:2.0.4"
+  checksum: 10c0/3170d16fccc0f4ac5e31323dbab7d0da7b1a4024878ed4d6b4ec86c0df94e12dc335f8d4181e38d97ca7919ac51bc5de4a9c2ec94914a4e51f9e9c05208c9ea9
   languageName: node
   linkType: hard
 
@@ -9862,6 +9870,13 @@ __metadata:
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
+  languageName: node
+  linkType: hard
+
+"inherits@npm:2.0.3":
+  version: 2.0.3
+  resolution: "inherits@npm:2.0.3"
+  checksum: 10c0/6e56402373149ea076a434072671f9982f5fad030c7662be0332122fe6c0fa490acb3cc1010d90b6eff8d640b1167d77674add52dfd1bb85d545cf29e80e73e7
   languageName: node
   linkType: hard
 
@@ -14358,6 +14373,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path@npm:^0.12.7":
+  version: 0.12.7
+  resolution: "path@npm:0.12.7"
+  dependencies:
+    process: "npm:^0.11.1"
+    util: "npm:^0.10.3"
+  checksum: 10c0/f795ce5438a988a590c7b6dfd450ec9baa1c391a8be4c2dea48baa6e0f5b199e56cd83b8c9ebf3991b81bea58236d2c32bdafe2c17a2e70c3a2e4c69891ade59
+  languageName: node
+  linkType: hard
+
 "peek-readable@npm:^5.1.3":
   version: 5.1.4
   resolution: "peek-readable@npm:5.1.4"
@@ -14628,6 +14653,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"process@npm:^0.11.1":
+  version: 0.11.10
+  resolution: "process@npm:0.11.10"
+  checksum: 10c0/40c3ce4b7e6d4b8c3355479df77aeed46f81b279818ccdc500124e6a5ab882c0cc81ff7ea16384873a95a74c4570b01b120f287abbdd4c877931460eca6084b3
+  languageName: node
+  linkType: hard
+
 "promise-retry@npm:^2.0.1":
   version: 2.0.1
   resolution: "promise-retry@npm:2.0.1"
@@ -14744,6 +14776,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"punycode@npm:^1.4.1":
+  version: 1.4.1
+  resolution: "punycode@npm:1.4.1"
+  checksum: 10c0/354b743320518aef36f77013be6e15da4db24c2b4f62c5f1eb0529a6ed02fbaf1cb52925785f6ab85a962f2b590d9cd5ad730b70da72b5f180e2556b8bd3ca08
+  languageName: node
+  linkType: hard
+
 "punycode@npm:^2.1.0, punycode@npm:^2.1.1":
   version: 2.3.1
   resolution: "punycode@npm:2.3.1"
@@ -14773,6 +14812,15 @@ __metadata:
   dependencies:
     side-channel: "npm:^1.0.4"
   checksum: 10c0/4e4875e4d7c7c31c233d07a448e7e4650f456178b9dd3766b7cfa13158fdb24ecb8c4f059fa91e820dc6ab9f2d243721d071c9c0378892dcdad86e9e9a27c68f
+  languageName: node
+  linkType: hard
+
+"qs@npm:^6.12.3":
+  version: 6.13.0
+  resolution: "qs@npm:6.13.0"
+  dependencies:
+    side-channel: "npm:^1.0.6"
+  checksum: 10c0/62372cdeec24dc83a9fb240b7533c0fdcf0c5f7e0b83343edd7310f0ab4c8205a5e7c56406531f2e47e1b4878a3821d652be4192c841de5b032ca83619d8f860
   languageName: node
   linkType: hard
 
@@ -16764,6 +16812,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"trpc-panel@npm:^1.3.4":
+  version: 1.3.4
+  resolution: "trpc-panel@npm:1.3.4"
+  dependencies:
+    fuzzysort: "npm:^2.0.4"
+    path: "npm:^0.12.7"
+    url: "npm:^0.11.0"
+    zod-to-json-schema: "npm:^3.20.0"
+  peerDependencies:
+    "@trpc/server": ^10.0.0
+    zod: ^3.19.1
+  checksum: 10c0/9f8e03ec80ea375e9dee0a4aab2af251779ea3f6bf8ce2ff4d1bde0c53a131298db735973bcf82cea42dc3d5657fddcfa053d25d89c062eda2130b7aa604f6af
+  languageName: node
+  linkType: hard
+
 "ts-api-utils@npm:^1.0.1, ts-api-utils@npm:^1.3.0":
   version: 1.3.0
   resolution: "ts-api-utils@npm:1.3.0"
@@ -17563,10 +17626,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"url@npm:^0.11.0":
+  version: 0.11.4
+  resolution: "url@npm:0.11.4"
+  dependencies:
+    punycode: "npm:^1.4.1"
+    qs: "npm:^6.12.3"
+  checksum: 10c0/cc93405ae4a9b97a2aa60ca67f1cb1481c0221cb4725a7341d149be5e2f9cfda26fd432d64dbbec693d16593b68b8a46aad8e5eab21f814932134c9d8620c662
+  languageName: node
+  linkType: hard
+
 "util-deprecate@npm:^1.0.1, util-deprecate@npm:^1.0.2, util-deprecate@npm:~1.0.1":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 10c0/41a5bdd214df2f6c3ecf8622745e4a366c4adced864bc3c833739791aeeeb1838119af7daed4ba36428114b5c67dcda034a79c882e97e43c03e66a4dd7389942
+  languageName: node
+  linkType: hard
+
+"util@npm:^0.10.3":
+  version: 0.10.4
+  resolution: "util@npm:0.10.4"
+  dependencies:
+    inherits: "npm:2.0.3"
+  checksum: 10c0/d29f6893e406b63b088ce9924da03201df89b31490d4d011f1c07a386ea4b3dbe907464c274023c237da470258e1805d806c7e4009a5974cd6b1d474b675852a
   languageName: node
   linkType: hard
 
@@ -18278,6 +18360,15 @@ __metadata:
   version: 2.1.2
   resolution: "yoctocolors-cjs@npm:2.1.2"
   checksum: 10c0/a0e36eb88fea2c7981eab22d1ba45e15d8d268626e6c4143305e2c1628fa17ebfaa40cd306161a8ce04c0a60ee0262058eab12567493d5eb1409780853454c6f
+  languageName: node
+  linkType: hard
+
+"zod-to-json-schema@npm:^3.20.0":
+  version: 3.23.3
+  resolution: "zod-to-json-schema@npm:3.23.3"
+  peerDependencies:
+    zod: ^3.23.3
+  checksum: 10c0/bbea65f28dd009e25940c038c73ad3a9bd5aeffd1a217dba7c44e59f3a3fe0476da3f65bbdde9bf4e65009557489e5b625420d9739871ea0c14e80c99968bf41
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR Aims to expose the runtime `AppRouter` object via Dependency Injection.
This can be done by importing `AppRouterHost` from `nestjs-trpc` and using the `appRouuter` getter method.

More notable additions:
- New documentation page called "Integrations", with an example of how to integrate `trpc-panel`.
- Extended the nest-express example to work with `trpc-panel`.

