### PR TITLE
feat: added fastify support

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -3445,6 +3445,47 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["@fastify/ajv-compiler", [\
+      ["npm:4.0.1", {\
+        "packageLocation": "../../.yarn/berry/cache/@fastify-ajv-compiler-npm-4.0.1-fef267081c-10c0.zip/node_modules/@fastify/ajv-compiler/",\
+        "packageDependencies": [\
+          ["@fastify/ajv-compiler", "npm:4.0.1"],\
+          ["ajv", "npm:8.17.1"],\
+          ["ajv-formats", "virtual:fef267081cdbabb1f4bf9bbf9fcaae65dbcff6d10275a8b7a2717546b9188fee5378783e3d901d136e65373026582350aa168c9fb29da1f6c445f545836b2fc6#npm:3.0.1"],\
+          ["fast-uri", "npm:3.0.2"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@fastify/error", [\
+      ["npm:4.0.0", {\
+        "packageLocation": "../../.yarn/berry/cache/@fastify-error-npm-4.0.0-855072728e-10c0.zip/node_modules/@fastify/error/",\
+        "packageDependencies": [\
+          ["@fastify/error", "npm:4.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@fastify/fast-json-stringify-compiler", [\
+      ["npm:5.0.1", {\
+        "packageLocation": "../../.yarn/berry/cache/@fastify-fast-json-stringify-compiler-npm-5.0.1-cd7a9bd969-10c0.zip/node_modules/@fastify/fast-json-stringify-compiler/",\
+        "packageDependencies": [\
+          ["@fastify/fast-json-stringify-compiler", "npm:5.0.1"],\
+          ["fast-json-stringify", "npm:6.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@fastify/merge-json-schemas", [\
+      ["npm:0.1.1", {\
+        "packageLocation": "../../.yarn/berry/cache/@fastify-merge-json-schemas-npm-0.1.1-12ae828277-10c0.zip/node_modules/@fastify/merge-json-schemas/",\
+        "packageDependencies": [\
+          ["@fastify/merge-json-schemas", "npm:0.1.1"],\
+          ["fast-deep-equal", "npm:3.1.3"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["@headlessui/react", [\
       ["npm:1.7.19", {\
         "packageLocation": "../../.yarn/berry/cache/@headlessui-react-npm-1.7.19-ac1b86d621-10c0.zip/node_modules/@headlessui/react/",\
@@ -7050,6 +7091,25 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["abort-controller", [\
+      ["npm:3.0.0", {\
+        "packageLocation": "../../.yarn/berry/cache/abort-controller-npm-3.0.0-2f3a9a2bcb-10c0.zip/node_modules/abort-controller/",\
+        "packageDependencies": [\
+          ["abort-controller", "npm:3.0.0"],\
+          ["event-target-shim", "npm:5.0.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["abstract-logging", [\
+      ["npm:2.0.1", {\
+        "packageLocation": "../../.yarn/berry/cache/abstract-logging-npm-2.0.1-b805b8edfa-10c0.zip/node_modules/abstract-logging/",\
+        "packageDependencies": [\
+          ["abstract-logging", "npm:2.0.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["accepts", [\
       ["npm:1.3.8", {\
         "packageLocation": "../../.yarn/berry/cache/accepts-npm-1.3.8-9a812371c9-10c0.zip/node_modules/accepts/",\
@@ -7219,12 +7279,32 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
+      ["npm:3.0.1", {\
+        "packageLocation": "../../.yarn/berry/cache/ajv-formats-npm-3.0.1-2662cf5b12-10c0.zip/node_modules/ajv-formats/",\
+        "packageDependencies": [\
+          ["ajv-formats", "npm:3.0.1"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
       ["virtual:d77e0e0a9d589a686aa0537e85e7c6c16ad75fccc1cc73e978f57116c6d7935e766fd8ec9a8ea1e3ebdc12a6b44f1d6dabd08e8ce69eb969266a592ac1092d73#npm:2.1.1", {\
         "packageLocation": "./.yarn/__virtual__/ajv-formats-virtual-dec24e272d/3/.yarn/berry/cache/ajv-formats-npm-2.1.1-3cec02eae9-10c0.zip/node_modules/ajv-formats/",\
         "packageDependencies": [\
           ["ajv-formats", "virtual:d77e0e0a9d589a686aa0537e85e7c6c16ad75fccc1cc73e978f57116c6d7935e766fd8ec9a8ea1e3ebdc12a6b44f1d6dabd08e8ce69eb969266a592ac1092d73#npm:2.1.1"],\
           ["@types/ajv", null],\
           ["ajv", "npm:8.12.0"]\
+        ],\
+        "packagePeers": [\
+          "@types/ajv",\
+          "ajv"\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["virtual:fef267081cdbabb1f4bf9bbf9fcaae65dbcff6d10275a8b7a2717546b9188fee5378783e3d901d136e65373026582350aa168c9fb29da1f6c445f545836b2fc6#npm:3.0.1", {\
+        "packageLocation": "./.yarn/__virtual__/ajv-formats-virtual-b88fd660f6/3/.yarn/berry/cache/ajv-formats-npm-3.0.1-2662cf5b12-10c0.zip/node_modules/ajv-formats/",\
+        "packageDependencies": [\
+          ["ajv-formats", "virtual:fef267081cdbabb1f4bf9bbf9fcaae65dbcff6d10275a8b7a2717546b9188fee5378783e3d901d136e65373026582350aa168c9fb29da1f6c445f545836b2fc6#npm:3.0.1"],\
+          ["@types/ajv", null],\
+          ["ajv", "npm:8.17.1"]\
         ],\
         "packagePeers": [\
           "@types/ajv",\
@@ -7648,6 +7728,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["atomic-sleep", [\
+      ["npm:1.0.0", {\
+        "packageLocation": "../../.yarn/berry/cache/atomic-sleep-npm-1.0.0-17d8a762a3-10c0.zip/node_modules/atomic-sleep/",\
+        "packageDependencies": [\
+          ["atomic-sleep", "npm:1.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["autoprefixer", [\
       ["npm:10.4.14", {\
         "packageLocation": "../../.yarn/berry/cache/autoprefixer-npm-10.4.14-1e0b8c34fb-10c0.zip/node_modules/autoprefixer/",\
@@ -7708,6 +7797,17 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["available-typed-arrays", "npm:1.0.7"],\
           ["possible-typed-array-names", "npm:1.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["avvio", [\
+      ["npm:9.0.0", {\
+        "packageLocation": "../../.yarn/berry/cache/avvio-npm-9.0.0-6d5708dcec-10c0.zip/node_modules/avvio/",\
+        "packageDependencies": [\
+          ["avvio", "npm:9.0.0"],\
+          ["@fastify/error", "npm:4.0.0"],\
+          ["fastq", "npm:1.17.1"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -8160,6 +8260,15 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../../.yarn/berry/cache/buffer-npm-5.7.1-513ef8259e-10c0.zip/node_modules/buffer/",\
         "packageDependencies": [\
           ["buffer", "npm:5.7.1"],\
+          ["base64-js", "npm:1.5.1"],\
+          ["ieee754", "npm:1.2.1"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:6.0.3", {\
+        "packageLocation": "../../.yarn/berry/cache/buffer-npm-6.0.3-cd90dfedfe-10c0.zip/node_modules/buffer/",\
+        "packageDependencies": [\
+          ["buffer", "npm:6.0.3"],\
           ["base64-js", "npm:1.5.1"],\
           ["ieee754", "npm:1.2.1"]\
         ],\
@@ -11518,6 +11627,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["event-target-shim", [\
+      ["npm:5.0.1", {\
+        "packageLocation": "../../.yarn/berry/cache/event-target-shim-npm-5.0.1-cb48709025-10c0.zip/node_modules/event-target-shim/",\
+        "packageDependencies": [\
+          ["event-target-shim", "npm:5.0.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["eventemitter3", [\
       ["npm:5.0.1", {\
         "packageLocation": "../../.yarn/berry/cache/eventemitter3-npm-5.0.1-5e423b7df3-10c0.zip/node_modules/eventemitter3/",\
@@ -11779,6 +11897,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["fast-decode-uri-component", [\
+      ["npm:1.0.1", {\
+        "packageLocation": "../../.yarn/berry/cache/fast-decode-uri-component-npm-1.0.1-578ba9fecf-10c0.zip/node_modules/fast-decode-uri-component/",\
+        "packageDependencies": [\
+          ["fast-decode-uri-component", "npm:1.0.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["fast-deep-equal", [\
       ["npm:3.1.3", {\
         "packageLocation": "../../.yarn/berry/cache/fast-deep-equal-npm-3.1.3-790edcfcf5-10c0.zip/node_modules/fast-deep-equal/",\
@@ -11820,11 +11947,46 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["fast-json-stringify", [\
+      ["npm:6.0.0", {\
+        "packageLocation": "../../.yarn/berry/cache/fast-json-stringify-npm-6.0.0-da1fe326b3-10c0.zip/node_modules/fast-json-stringify/",\
+        "packageDependencies": [\
+          ["fast-json-stringify", "npm:6.0.0"],\
+          ["@fastify/merge-json-schemas", "npm:0.1.1"],\
+          ["ajv", "npm:8.17.1"],\
+          ["ajv-formats", "virtual:fef267081cdbabb1f4bf9bbf9fcaae65dbcff6d10275a8b7a2717546b9188fee5378783e3d901d136e65373026582350aa168c9fb29da1f6c445f545836b2fc6#npm:3.0.1"],\
+          ["fast-deep-equal", "npm:3.1.3"],\
+          ["fast-uri", "npm:2.4.0"],\
+          ["json-schema-ref-resolver", "npm:1.0.1"],\
+          ["rfdc", "npm:1.4.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["fast-levenshtein", [\
       ["npm:2.0.6", {\
         "packageLocation": "../../.yarn/berry/cache/fast-levenshtein-npm-2.0.6-fcd74b8df5-10c0.zip/node_modules/fast-levenshtein/",\
         "packageDependencies": [\
           ["fast-levenshtein", "npm:2.0.6"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["fast-querystring", [\
+      ["npm:1.1.2", {\
+        "packageLocation": "../../.yarn/berry/cache/fast-querystring-npm-1.1.2-81dfb4019b-10c0.zip/node_modules/fast-querystring/",\
+        "packageDependencies": [\
+          ["fast-querystring", "npm:1.1.2"],\
+          ["fast-decode-uri-component", "npm:1.0.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["fast-redact", [\
+      ["npm:3.5.0", {\
+        "packageLocation": "../../.yarn/berry/cache/fast-redact-npm-3.5.0-80acfe2b04-10c0.zip/node_modules/fast-redact/",\
+        "packageDependencies": [\
+          ["fast-redact", "npm:3.5.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -11839,10 +12001,48 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["fast-uri", [\
+      ["npm:2.4.0", {\
+        "packageLocation": "../../.yarn/berry/cache/fast-uri-npm-2.4.0-41c8a2d2ef-10c0.zip/node_modules/fast-uri/",\
+        "packageDependencies": [\
+          ["fast-uri", "npm:2.4.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["npm:3.0.1", {\
         "packageLocation": "../../.yarn/berry/cache/fast-uri-npm-3.0.1-20477a5d16-10c0.zip/node_modules/fast-uri/",\
         "packageDependencies": [\
           ["fast-uri", "npm:3.0.1"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:3.0.2", {\
+        "packageLocation": "../../.yarn/berry/cache/fast-uri-npm-3.0.2-d822390ead-10c0.zip/node_modules/fast-uri/",\
+        "packageDependencies": [\
+          ["fast-uri", "npm:3.0.2"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["fastify", [\
+      ["npm:5.0.0", {\
+        "packageLocation": "../../.yarn/berry/cache/fastify-npm-5.0.0-068fe29859-10c0.zip/node_modules/fastify/",\
+        "packageDependencies": [\
+          ["fastify", "npm:5.0.0"],\
+          ["@fastify/ajv-compiler", "npm:4.0.1"],\
+          ["@fastify/error", "npm:4.0.0"],\
+          ["@fastify/fast-json-stringify-compiler", "npm:5.0.1"],\
+          ["abstract-logging", "npm:2.0.1"],\
+          ["avvio", "npm:9.0.0"],\
+          ["fast-json-stringify", "npm:6.0.0"],\
+          ["find-my-way", "npm:9.1.0"],\
+          ["light-my-request", "npm:6.0.0"],\
+          ["pino", "npm:9.4.0"],\
+          ["process-warning", "npm:4.0.0"],\
+          ["proxy-addr", "npm:2.0.7"],\
+          ["rfdc", "npm:1.4.1"],\
+          ["secure-json-parse", "npm:2.7.0"],\
+          ["semver", "npm:7.6.3"],\
+          ["toad-cache", "npm:3.7.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -11963,6 +12163,18 @@ const RAW_RUNTIME_STATE =
           ["parseurl", "npm:1.3.3"],\
           ["statuses", "npm:2.0.1"],\
           ["unpipe", "npm:1.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["find-my-way", [\
+      ["npm:9.1.0", {\
+        "packageLocation": "../../.yarn/berry/cache/find-my-way-npm-9.1.0-0f4affcdb6-10c0.zip/node_modules/find-my-way/",\
+        "packageDependencies": [\
+          ["find-my-way", "npm:9.1.0"],\
+          ["fast-deep-equal", "npm:3.1.3"],\
+          ["fast-querystring", "npm:1.1.2"],\
+          ["safe-regex2", "npm:4.0.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -15019,6 +15231,16 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["json-schema-ref-resolver", [\
+      ["npm:1.0.1", {\
+        "packageLocation": "../../.yarn/berry/cache/json-schema-ref-resolver-npm-1.0.1-b4bc8e91c0-10c0.zip/node_modules/json-schema-ref-resolver/",\
+        "packageDependencies": [\
+          ["json-schema-ref-resolver", "npm:1.0.1"],\
+          ["fast-deep-equal", "npm:3.1.3"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["json-schema-traverse", [\
       ["npm:0.4.1", {\
         "packageLocation": "../../.yarn/berry/cache/json-schema-traverse-npm-0.4.1-4759091693-10c0.zip/node_modules/json-schema-traverse/",\
@@ -15234,6 +15456,18 @@ const RAW_RUNTIME_STATE =
           ["levn", "npm:0.4.1"],\
           ["prelude-ls", "npm:1.2.1"],\
           ["type-check", "npm:0.4.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["light-my-request", [\
+      ["npm:6.0.0", {\
+        "packageLocation": "../../.yarn/berry/cache/light-my-request-npm-6.0.0-cef4f96109-10c0.zip/node_modules/light-my-request/",\
+        "packageDependencies": [\
+          ["light-my-request", "npm:6.0.0"],\
+          ["cookie", "npm:0.6.0"],\
+          ["process-warning", "npm:4.0.0"],\
+          ["set-cookie-parser", "npm:2.7.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -17086,6 +17320,7 @@ const RAW_RUNTIME_STATE =
           ["@types/rxjs", null],\
           ["@types/trpc__server", null],\
           ["@types/zod", null],\
+          ["fastify", "npm:5.0.0"],\
           ["func-loc", "npm:0.1.16"],\
           ["jest", "virtual:e8c2026326350578d02b68ad535fd35e48f18c0982f4815fcbf4f100a889dce5bd7633118913a4c281bc0db311d4afa92fce0fce29e476de8880d9feed95eb0b#npm:29.7.0"],\
           ["lodash", "npm:4.17.21"],\
@@ -17128,6 +17363,7 @@ const RAW_RUNTIME_STATE =
           ["@types/jest", "npm:29.5.12"],\
           ["@types/lodash", "npm:4.17.7"],\
           ["@types/node", "npm:22.5.0"],\
+          ["fastify", "npm:5.0.0"],\
           ["func-loc", "npm:0.1.16"],\
           ["jest", "virtual:e8c2026326350578d02b68ad535fd35e48f18c0982f4815fcbf4f100a889dce5bd7633118913a4c281bc0db311d4afa92fce0fce29e476de8880d9feed95eb0b#npm:29.7.0"],\
           ["lodash", "npm:4.17.21"],\
@@ -17919,6 +18155,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["on-exit-leak-free", [\
+      ["npm:2.1.2", {\
+        "packageLocation": "../../.yarn/berry/cache/on-exit-leak-free-npm-2.1.2-0d0c5ad67d-10c0.zip/node_modules/on-exit-leak-free/",\
+        "packageDependencies": [\
+          ["on-exit-leak-free", "npm:2.1.2"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["on-finished", [\
       ["npm:2.4.1", {\
         "packageLocation": "../../.yarn/berry/cache/on-finished-npm-2.4.1-907af70f88-10c0.zip/node_modules/on-finished/",\
@@ -18524,6 +18769,46 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["pino", [\
+      ["npm:9.4.0", {\
+        "packageLocation": "../../.yarn/berry/cache/pino-npm-9.4.0-ddd67db852-10c0.zip/node_modules/pino/",\
+        "packageDependencies": [\
+          ["pino", "npm:9.4.0"],\
+          ["atomic-sleep", "npm:1.0.0"],\
+          ["fast-redact", "npm:3.5.0"],\
+          ["on-exit-leak-free", "npm:2.1.2"],\
+          ["pino-abstract-transport", "npm:1.2.0"],\
+          ["pino-std-serializers", "npm:7.0.0"],\
+          ["process-warning", "npm:4.0.0"],\
+          ["quick-format-unescaped", "npm:4.0.4"],\
+          ["real-require", "npm:0.2.0"],\
+          ["safe-stable-stringify", "npm:2.5.0"],\
+          ["sonic-boom", "npm:4.1.0"],\
+          ["thread-stream", "npm:3.1.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["pino-abstract-transport", [\
+      ["npm:1.2.0", {\
+        "packageLocation": "../../.yarn/berry/cache/pino-abstract-transport-npm-1.2.0-8567d0d819-10c0.zip/node_modules/pino-abstract-transport/",\
+        "packageDependencies": [\
+          ["pino-abstract-transport", "npm:1.2.0"],\
+          ["readable-stream", "npm:4.5.2"],\
+          ["split2", "npm:4.2.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["pino-std-serializers", [\
+      ["npm:7.0.0", {\
+        "packageLocation": "../../.yarn/berry/cache/pino-std-serializers-npm-7.0.0-94d470ae0c-10c0.zip/node_modules/pino-std-serializers/",\
+        "packageDependencies": [\
+          ["pino-std-serializers", "npm:7.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["pinst", [\
       ["npm:3.0.0", {\
         "packageLocation": "../../.yarn/berry/cache/pinst-npm-3.0.0-5d2b6c1dda-10c0.zip/node_modules/pinst/",\
@@ -18808,6 +19093,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["process-warning", [\
+      ["npm:4.0.0", {\
+        "packageLocation": "../../.yarn/berry/cache/process-warning-npm-4.0.0-d61ed74d22-10c0.zip/node_modules/process-warning/",\
+        "packageDependencies": [\
+          ["process-warning", "npm:4.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["promise-retry", [\
       ["npm:2.0.1", {\
         "packageLocation": "../../.yarn/berry/cache/promise-retry-npm-2.0.1-871f0b01b7-10c0.zip/node_modules/promise-retry/",\
@@ -18999,6 +19293,15 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../../.yarn/berry/cache/queue-microtask-npm-1.2.3-fcc98e4e2d-10c0.zip/node_modules/queue-microtask/",\
         "packageDependencies": [\
           ["queue-microtask", "npm:1.2.3"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["quick-format-unescaped", [\
+      ["npm:4.0.4", {\
+        "packageLocation": "../../.yarn/berry/cache/quick-format-unescaped-npm-4.0.4-7e22c9b7dc-10c0.zip/node_modules/quick-format-unescaped/",\
+        "packageDependencies": [\
+          ["quick-format-unescaped", "npm:4.0.4"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -19196,6 +19499,18 @@ const RAW_RUNTIME_STATE =
           ["util-deprecate", "npm:1.0.2"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:4.5.2", {\
+        "packageLocation": "../../.yarn/berry/cache/readable-stream-npm-4.5.2-4a1062e2a4-10c0.zip/node_modules/readable-stream/",\
+        "packageDependencies": [\
+          ["readable-stream", "npm:4.5.2"],\
+          ["abort-controller", "npm:3.0.0"],\
+          ["buffer", "npm:6.0.3"],\
+          ["events", "npm:3.3.0"],\
+          ["process", "npm:0.11.10"],\
+          ["string_decoder", "npm:1.3.0"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["readable-web-to-node-stream", [\
@@ -19223,6 +19538,15 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../../.yarn/berry/cache/reading-time-npm-1.5.0-be83d947c6-10c0.zip/node_modules/reading-time/",\
         "packageDependencies": [\
           ["reading-time", "npm:1.5.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["real-require", [\
+      ["npm:0.2.0", {\
+        "packageLocation": "../../.yarn/berry/cache/real-require-npm-0.2.0-7f69dbc7b6-10c0.zip/node_modules/real-require/",\
+        "packageDependencies": [\
+          ["real-require", "npm:0.2.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -19698,6 +20022,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["ret", [\
+      ["npm:0.5.0", {\
+        "packageLocation": "../../.yarn/berry/cache/ret-npm-0.5.0-80249185b8-10c0.zip/node_modules/ret/",\
+        "packageDependencies": [\
+          ["ret", "npm:0.5.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["retry", [\
       ["npm:0.12.0", {\
         "packageLocation": "../../.yarn/berry/cache/retry-npm-0.12.0-72ac7fb4cc-10c0.zip/node_modules/retry/",\
@@ -19865,6 +20198,25 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["safe-regex2", [\
+      ["npm:4.0.0", {\
+        "packageLocation": "../../.yarn/berry/cache/safe-regex2-npm-4.0.0-e09ce0e704-10c0.zip/node_modules/safe-regex2/",\
+        "packageDependencies": [\
+          ["safe-regex2", "npm:4.0.0"],\
+          ["ret", "npm:0.5.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["safe-stable-stringify", [\
+      ["npm:2.5.0", {\
+        "packageLocation": "../../.yarn/berry/cache/safe-stable-stringify-npm-2.5.0-42ba8d9d22-10c0.zip/node_modules/safe-stable-stringify/",\
+        "packageDependencies": [\
+          ["safe-stable-stringify", "npm:2.5.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["safer-buffer", [\
       ["npm:2.1.2", {\
         "packageLocation": "../../.yarn/berry/cache/safer-buffer-npm-2.1.2-8d5c0b705e-10c0.zip/node_modules/safer-buffer/",\
@@ -19913,6 +20265,15 @@ const RAW_RUNTIME_STATE =
           ["section-matter", "npm:1.0.0"],\
           ["extend-shallow", "npm:2.0.1"],\
           ["kind-of", "npm:6.0.3"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["secure-json-parse", [\
+      ["npm:2.7.0", {\
+        "packageLocation": "../../.yarn/berry/cache/secure-json-parse-npm-2.7.0-d5b89b0a3e-10c0.zip/node_modules/secure-json-parse/",\
+        "packageDependencies": [\
+          ["secure-json-parse", "npm:2.7.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -20020,6 +20381,15 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../../.yarn/berry/cache/server-only-npm-0.0.1-24bf42bde2-10c0.zip/node_modules/server-only/",\
         "packageDependencies": [\
           ["server-only", "npm:0.0.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["set-cookie-parser", [\
+      ["npm:2.7.0", {\
+        "packageLocation": "../../.yarn/berry/cache/set-cookie-parser-npm-2.7.0-f8857d236c-10c0.zip/node_modules/set-cookie-parser/",\
+        "packageDependencies": [\
+          ["set-cookie-parser", "npm:2.7.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -20233,6 +20603,16 @@ const RAW_RUNTIME_STATE =
           ["agent-base", "npm:7.1.1"],\
           ["debug", "virtual:3837a202e2f100c9259f49e0d610856d919fb02a54d6397a0f9765b8b1b52dea715f884a6c583b5fe84dff97ba9428d67e0d0225d3858e9ef42da3d22877f3a2#npm:4.3.6"],\
           ["socks", "npm:2.8.3"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["sonic-boom", [\
+      ["npm:4.1.0", {\
+        "packageLocation": "../../.yarn/berry/cache/sonic-boom-npm-4.1.0-28f434d5a2-10c0.zip/node_modules/sonic-boom/",\
+        "packageDependencies": [\
+          ["sonic-boom", "npm:4.1.0"],\
+          ["atomic-sleep", "npm:1.0.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -21099,6 +21479,16 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["thread-stream", [\
+      ["npm:3.1.0", {\
+        "packageLocation": "../../.yarn/berry/cache/thread-stream-npm-3.1.0-ac5663dfb7-10c0.zip/node_modules/thread-stream/",\
+        "packageDependencies": [\
+          ["thread-stream", "npm:3.1.0"],\
+          ["real-require", "npm:0.2.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["through", [\
       ["npm:2.3.8", {\
         "packageLocation": "../../.yarn/berry/cache/through-npm-2.3.8-df5f72a16e-10c0.zip/node_modules/through/",\
@@ -21164,6 +21554,15 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["to-regex-range", "npm:5.0.1"],\
           ["is-number", "npm:7.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["toad-cache", [\
+      ["npm:3.7.0", {\
+        "packageLocation": "../../.yarn/berry/cache/toad-cache-npm-3.7.0-ece522d0b8-10c0.zip/node_modules/toad-cache/",\
+        "packageDependencies": [\
+          ["toad-cache", "npm:3.7.0"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -23,6 +23,10 @@ const RAW_RUNTIME_STATE =
       "reference": "workspace:examples/nestjs-express"\
     },\
     {\
+      "name": "example-nestjs-fastify",\
+      "reference": "workspace:examples/nestjs-fastify"\
+    },\
+    {\
       "name": "web",\
       "reference": "workspace:examples/nextjs-trpc"\
     },\
@@ -35,7 +39,8 @@ const RAW_RUNTIME_STATE =
   "ignorePatternData": "(^(?:\\\\.yarn\\\\/sdks(?:\\\\/(?!\\\\.{1,2}(?:\\\\/|$))(?:(?:(?!(?:^|\\\\/)\\\\.{1,2}(?:\\\\/|$)).)*?)|$))$)",\
   "fallbackExclusionList": [\
     ["example-nestjs-express", ["workspace:examples/nestjs-express"]],\
-    ["nestjs-trpc", ["virtual:1d5ebb853d503e6fea373f31bf5c65a3d6b7a77f545a96c962e755e47337c3e496ed5cee7282e41167a1f4dfa23fb3acbbefc04d81bed7ec8f8b7c619015ae65#workspace:packages/nestjs-trpc", "workspace:packages/nestjs-trpc"]],\
+    ["example-nestjs-fastify", ["workspace:examples/nestjs-fastify"]],\
+    ["nestjs-trpc", ["virtual:1d5ebb853d503e6fea373f31bf5c65a3d6b7a77f545a96c962e755e47337c3e496ed5cee7282e41167a1f4dfa23fb3acbbefc04d81bed7ec8f8b7c619015ae65#workspace:packages/nestjs-trpc", "virtual:2bca6e3cbb4cd21ddce3b7d86d352a949459bf0520cd22c37c69c2f84be3cf6f50b3e9c7739215326a81a0a61eeba592973c9bca0bcdde30cfddd2e91303015d#workspace:packages/nestjs-trpc", "workspace:packages/nestjs-trpc"]],\
     ["nestjs-trpc-workspace", ["workspace:."]],\
     ["nestjs-trpc.io", ["workspace:docs"]],\
     ["web", ["workspace:examples/nextjs-trpc"]]\
@@ -3446,6 +3451,16 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@fastify/ajv-compiler", [\
+      ["npm:3.6.0", {\
+        "packageLocation": "../../.yarn/berry/cache/@fastify-ajv-compiler-npm-3.6.0-7829894d28-10c0.zip/node_modules/@fastify/ajv-compiler/",\
+        "packageDependencies": [\
+          ["@fastify/ajv-compiler", "npm:3.6.0"],\
+          ["ajv", "npm:8.17.1"],\
+          ["ajv-formats", "virtual:7829894d28c8a8d3057330c2b7c50cfc5c973bde34019e491cfdc30eab0c1d1dfa7d3950859fd8a529e259abe38bf4467241609af1f814ac92ec592e40531326#npm:2.1.1"],\
+          ["fast-uri", "npm:2.4.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["npm:4.0.1", {\
         "packageLocation": "../../.yarn/berry/cache/@fastify-ajv-compiler-npm-4.0.1-fef267081c-10c0.zip/node_modules/@fastify/ajv-compiler/",\
         "packageDependencies": [\
@@ -3457,7 +3472,25 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["@fastify/cors", [\
+      ["npm:9.0.1", {\
+        "packageLocation": "../../.yarn/berry/cache/@fastify-cors-npm-9.0.1-738ce8930b-10c0.zip/node_modules/@fastify/cors/",\
+        "packageDependencies": [\
+          ["@fastify/cors", "npm:9.0.1"],\
+          ["fastify-plugin", "npm:4.5.1"],\
+          ["mnemonist", "npm:0.39.6"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["@fastify/error", [\
+      ["npm:3.4.1", {\
+        "packageLocation": "../../.yarn/berry/cache/@fastify-error-npm-3.4.1-eaa74ed572-10c0.zip/node_modules/@fastify/error/",\
+        "packageDependencies": [\
+          ["@fastify/error", "npm:3.4.1"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["npm:4.0.0", {\
         "packageLocation": "../../.yarn/berry/cache/@fastify-error-npm-4.0.0-855072728e-10c0.zip/node_modules/@fastify/error/",\
         "packageDependencies": [\
@@ -3467,11 +3500,30 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@fastify/fast-json-stringify-compiler", [\
+      ["npm:4.3.0", {\
+        "packageLocation": "../../.yarn/berry/cache/@fastify-fast-json-stringify-compiler-npm-4.3.0-920872cc57-10c0.zip/node_modules/@fastify/fast-json-stringify-compiler/",\
+        "packageDependencies": [\
+          ["@fastify/fast-json-stringify-compiler", "npm:4.3.0"],\
+          ["fast-json-stringify", "npm:5.16.1"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["npm:5.0.1", {\
         "packageLocation": "../../.yarn/berry/cache/@fastify-fast-json-stringify-compiler-npm-5.0.1-cd7a9bd969-10c0.zip/node_modules/@fastify/fast-json-stringify-compiler/",\
         "packageDependencies": [\
           ["@fastify/fast-json-stringify-compiler", "npm:5.0.1"],\
           ["fast-json-stringify", "npm:6.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@fastify/formbody", [\
+      ["npm:7.4.0", {\
+        "packageLocation": "../../.yarn/berry/cache/@fastify-formbody-npm-7.4.0-e688760e8b-10c0.zip/node_modules/@fastify/formbody/",\
+        "packageDependencies": [\
+          ["@fastify/formbody", "npm:7.4.0"],\
+          ["fast-querystring", "npm:1.1.2"],\
+          ["fastify-plugin", "npm:4.5.1"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -3482,6 +3534,19 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@fastify/merge-json-schemas", "npm:0.1.1"],\
           ["fast-deep-equal", "npm:3.1.3"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@fastify/middie", [\
+      ["npm:8.3.3", {\
+        "packageLocation": "../../.yarn/berry/cache/@fastify-middie-npm-8.3.3-a3701deff6-10c0.zip/node_modules/@fastify/middie/",\
+        "packageDependencies": [\
+          ["@fastify/middie", "npm:8.3.3"],\
+          ["@fastify/error", "npm:3.4.1"],\
+          ["fastify-plugin", "npm:4.5.1"],\
+          ["path-to-regexp", "npm:6.3.0"],\
+          ["reusify", "npm:1.0.4"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -4385,6 +4450,45 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
+      ["virtual:2bca6e3cbb4cd21ddce3b7d86d352a949459bf0520cd22c37c69c2f84be3cf6f50b3e9c7739215326a81a0a61eeba592973c9bca0bcdde30cfddd2e91303015d#npm:10.4.1", {\
+        "packageLocation": "./.yarn/unplugged/@nestjs-core-virtual-7ad7a071b3/node_modules/@nestjs/core/",\
+        "packageDependencies": [\
+          ["@nestjs/core", "virtual:2bca6e3cbb4cd21ddce3b7d86d352a949459bf0520cd22c37c69c2f84be3cf6f50b3e9c7739215326a81a0a61eeba592973c9bca0bcdde30cfddd2e91303015d#npm:10.4.1"],\
+          ["@nestjs/common", "virtual:1d5ebb853d503e6fea373f31bf5c65a3d6b7a77f545a96c962e755e47337c3e496ed5cee7282e41167a1f4dfa23fb3acbbefc04d81bed7ec8f8b7c619015ae65#npm:10.4.1"],\
+          ["@nestjs/microservices", null],\
+          ["@nestjs/platform-express", null],\
+          ["@nestjs/websockets", null],\
+          ["@nuxtjs/opencollective", "npm:0.3.2"],\
+          ["@types/nestjs__common", null],\
+          ["@types/nestjs__microservices", null],\
+          ["@types/nestjs__platform-express", null],\
+          ["@types/nestjs__websockets", null],\
+          ["@types/reflect-metadata", null],\
+          ["@types/rxjs", null],\
+          ["fast-safe-stringify", "npm:2.1.1"],\
+          ["iterare", "npm:1.2.1"],\
+          ["path-to-regexp", "npm:3.2.0"],\
+          ["reflect-metadata", "npm:0.1.14"],\
+          ["rxjs", "npm:7.8.1"],\
+          ["tslib", "npm:2.6.3"],\
+          ["uid", "npm:2.0.2"]\
+        ],\
+        "packagePeers": [\
+          "@nestjs/common",\
+          "@nestjs/microservices",\
+          "@nestjs/platform-express",\
+          "@nestjs/websockets",\
+          "@types/nestjs__common",\
+          "@types/nestjs__microservices",\
+          "@types/nestjs__platform-express",\
+          "@types/nestjs__websockets",\
+          "@types/reflect-metadata",\
+          "@types/rxjs",\
+          "reflect-metadata",\
+          "rxjs"\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["virtual:651009747fdeab0d85696903b04fbb12f5006a6635b0fd9dd3ef9a43227fa179b0ff2ee449c66fa2b9d34a8234b8a0e861a55336468794ada9e3553d1fe0dffb#npm:10.4.1", {\
         "packageLocation": "./.yarn/unplugged/@nestjs-core-virtual-67cbb9e351/node_modules/@nestjs/core/",\
         "packageDependencies": [\
@@ -4450,6 +4554,47 @@ const RAW_RUNTIME_STATE =
         "packagePeers": [\
           "@nestjs/common",\
           "@nestjs/core",\
+          "@types/nestjs__common",\
+          "@types/nestjs__core"\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@nestjs/platform-fastify", [\
+      ["npm:10.4.4", {\
+        "packageLocation": "../../.yarn/berry/cache/@nestjs-platform-fastify-npm-10.4.4-4d865a202a-10c0.zip/node_modules/@nestjs/platform-fastify/",\
+        "packageDependencies": [\
+          ["@nestjs/platform-fastify", "npm:10.4.4"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:2bca6e3cbb4cd21ddce3b7d86d352a949459bf0520cd22c37c69c2f84be3cf6f50b3e9c7739215326a81a0a61eeba592973c9bca0bcdde30cfddd2e91303015d#npm:10.4.4", {\
+        "packageLocation": "./.yarn/__virtual__/@nestjs-platform-fastify-virtual-ac4e142a17/3/.yarn/berry/cache/@nestjs-platform-fastify-npm-10.4.4-4d865a202a-10c0.zip/node_modules/@nestjs/platform-fastify/",\
+        "packageDependencies": [\
+          ["@nestjs/platform-fastify", "virtual:2bca6e3cbb4cd21ddce3b7d86d352a949459bf0520cd22c37c69c2f84be3cf6f50b3e9c7739215326a81a0a61eeba592973c9bca0bcdde30cfddd2e91303015d#npm:10.4.4"],\
+          ["@fastify/cors", "npm:9.0.1"],\
+          ["@fastify/formbody", "npm:7.4.0"],\
+          ["@fastify/middie", "npm:8.3.3"],\
+          ["@fastify/static", null],\
+          ["@fastify/view", null],\
+          ["@nestjs/common", "virtual:1d5ebb853d503e6fea373f31bf5c65a3d6b7a77f545a96c962e755e47337c3e496ed5cee7282e41167a1f4dfa23fb3acbbefc04d81bed7ec8f8b7c619015ae65#npm:10.4.1"],\
+          ["@nestjs/core", "virtual:2bca6e3cbb4cd21ddce3b7d86d352a949459bf0520cd22c37c69c2f84be3cf6f50b3e9c7739215326a81a0a61eeba592973c9bca0bcdde30cfddd2e91303015d#npm:10.4.1"],\
+          ["@types/fastify__static", null],\
+          ["@types/fastify__view", null],\
+          ["@types/nestjs__common", null],\
+          ["@types/nestjs__core", null],\
+          ["fastify", "npm:4.28.1"],\
+          ["light-my-request", "npm:6.0.0"],\
+          ["path-to-regexp", "npm:3.3.0"],\
+          ["tslib", "npm:2.7.0"]\
+        ],\
+        "packagePeers": [\
+          "@fastify/static",\
+          "@fastify/view",\
+          "@nestjs/common",\
+          "@nestjs/core",\
+          "@types/fastify__static",\
+          "@types/fastify__view",\
           "@types/nestjs__common",\
           "@types/nestjs__core"\
         ],\
@@ -4539,6 +4684,32 @@ const RAW_RUNTIME_STATE =
           ["@nestjs/testing", "virtual:651009747fdeab0d85696903b04fbb12f5006a6635b0fd9dd3ef9a43227fa179b0ff2ee449c66fa2b9d34a8234b8a0e861a55336468794ada9e3553d1fe0dffb#npm:10.4.1"],\
           ["@nestjs/common", "virtual:651009747fdeab0d85696903b04fbb12f5006a6635b0fd9dd3ef9a43227fa179b0ff2ee449c66fa2b9d34a8234b8a0e861a55336468794ada9e3553d1fe0dffb#npm:10.4.1"],\
           ["@nestjs/core", "virtual:651009747fdeab0d85696903b04fbb12f5006a6635b0fd9dd3ef9a43227fa179b0ff2ee449c66fa2b9d34a8234b8a0e861a55336468794ada9e3553d1fe0dffb#npm:10.4.1"],\
+          ["@nestjs/microservices", null],\
+          ["@nestjs/platform-express", null],\
+          ["@types/nestjs__common", null],\
+          ["@types/nestjs__core", null],\
+          ["@types/nestjs__microservices", null],\
+          ["@types/nestjs__platform-express", null],\
+          ["tslib", "npm:2.6.3"]\
+        ],\
+        "packagePeers": [\
+          "@nestjs/common",\
+          "@nestjs/core",\
+          "@nestjs/microservices",\
+          "@nestjs/platform-express",\
+          "@types/nestjs__common",\
+          "@types/nestjs__core",\
+          "@types/nestjs__microservices",\
+          "@types/nestjs__platform-express"\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["virtual:be79e81d01e86a010006ee71d7112b5a7c2871f4c93ebdf7486ab7900046d396459596f12aa8e76a6c189f0c76843b655ef596ef474d45878137d5dcd77b6028#npm:10.4.1", {\
+        "packageLocation": "./.yarn/__virtual__/@nestjs-testing-virtual-86bcf4c44e/3/.yarn/berry/cache/@nestjs-testing-npm-10.4.1-7172a7cc82-10c0.zip/node_modules/@nestjs/testing/",\
+        "packageDependencies": [\
+          ["@nestjs/testing", "virtual:be79e81d01e86a010006ee71d7112b5a7c2871f4c93ebdf7486ab7900046d396459596f12aa8e76a6c189f0c76843b655ef596ef474d45878137d5dcd77b6028#npm:10.4.1"],\
+          ["@nestjs/common", "virtual:1d5ebb853d503e6fea373f31bf5c65a3d6b7a77f545a96c962e755e47337c3e496ed5cee7282e41167a1f4dfa23fb3acbbefc04d81bed7ec8f8b7c619015ae65#npm:10.4.1"],\
+          ["@nestjs/core", "virtual:2bca6e3cbb4cd21ddce3b7d86d352a949459bf0520cd22c37c69c2f84be3cf6f50b3e9c7739215326a81a0a61eeba592973c9bca0bcdde30cfddd2e91303015d#npm:10.4.1"],\
           ["@nestjs/microservices", null],\
           ["@nestjs/platform-express", null],\
           ["@types/nestjs__common", null],\
@@ -7286,6 +7457,19 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
+      ["virtual:7829894d28c8a8d3057330c2b7c50cfc5c973bde34019e491cfdc30eab0c1d1dfa7d3950859fd8a529e259abe38bf4467241609af1f814ac92ec592e40531326#npm:2.1.1", {\
+        "packageLocation": "./.yarn/__virtual__/ajv-formats-virtual-f60122cace/3/.yarn/berry/cache/ajv-formats-npm-2.1.1-3cec02eae9-10c0.zip/node_modules/ajv-formats/",\
+        "packageDependencies": [\
+          ["ajv-formats", "virtual:7829894d28c8a8d3057330c2b7c50cfc5c973bde34019e491cfdc30eab0c1d1dfa7d3950859fd8a529e259abe38bf4467241609af1f814ac92ec592e40531326#npm:2.1.1"],\
+          ["@types/ajv", null],\
+          ["ajv", "npm:8.17.1"]\
+        ],\
+        "packagePeers": [\
+          "@types/ajv",\
+          "ajv"\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["virtual:d77e0e0a9d589a686aa0537e85e7c6c16ad75fccc1cc73e978f57116c6d7935e766fd8ec9a8ea1e3ebdc12a6b44f1d6dabd08e8ce69eb969266a592ac1092d73#npm:2.1.1", {\
         "packageLocation": "./.yarn/__virtual__/ajv-formats-virtual-dec24e272d/3/.yarn/berry/cache/ajv-formats-npm-2.1.1-3cec02eae9-10c0.zip/node_modules/ajv-formats/",\
         "packageDependencies": [\
@@ -7802,6 +7986,15 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["avvio", [\
+      ["npm:8.4.0", {\
+        "packageLocation": "../../.yarn/berry/cache/avvio-npm-8.4.0-36effa14c8-10c0.zip/node_modules/avvio/",\
+        "packageDependencies": [\
+          ["avvio", "npm:8.4.0"],\
+          ["@fastify/error", "npm:3.4.1"],\
+          ["fastq", "npm:1.17.1"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["npm:9.0.0", {\
         "packageLocation": "../../.yarn/berry/cache/avvio-npm-9.0.0-6d5708dcec-10c0.zip/node_modules/avvio/",\
         "packageDependencies": [\
@@ -11685,6 +11878,37 @@ const RAW_RUNTIME_STATE =
         "linkType": "SOFT"\
       }]\
     ]],\
+    ["example-nestjs-fastify", [\
+      ["workspace:examples/nestjs-fastify", {\
+        "packageLocation": "./examples/nestjs-fastify/",\
+        "packageDependencies": [\
+          ["example-nestjs-fastify", "workspace:examples/nestjs-fastify"],\
+          ["@nestjs/cli", "virtual:1d5ebb853d503e6fea373f31bf5c65a3d6b7a77f545a96c962e755e47337c3e496ed5cee7282e41167a1f4dfa23fb3acbbefc04d81bed7ec8f8b7c619015ae65#npm:10.4.4"],\
+          ["@nestjs/common", "virtual:1d5ebb853d503e6fea373f31bf5c65a3d6b7a77f545a96c962e755e47337c3e496ed5cee7282e41167a1f4dfa23fb3acbbefc04d81bed7ec8f8b7c619015ae65#npm:10.4.1"],\
+          ["@nestjs/config", "virtual:1d5ebb853d503e6fea373f31bf5c65a3d6b7a77f545a96c962e755e47337c3e496ed5cee7282e41167a1f4dfa23fb3acbbefc04d81bed7ec8f8b7c619015ae65#npm:3.2.3"],\
+          ["@nestjs/core", "virtual:2bca6e3cbb4cd21ddce3b7d86d352a949459bf0520cd22c37c69c2f84be3cf6f50b3e9c7739215326a81a0a61eeba592973c9bca0bcdde30cfddd2e91303015d#npm:10.4.1"],\
+          ["@nestjs/platform-fastify", "virtual:2bca6e3cbb4cd21ddce3b7d86d352a949459bf0520cd22c37c69c2f84be3cf6f50b3e9c7739215326a81a0a61eeba592973c9bca0bcdde30cfddd2e91303015d#npm:10.4.4"],\
+          ["@nestjs/schematics", "virtual:1d5ebb853d503e6fea373f31bf5c65a3d6b7a77f545a96c962e755e47337c3e496ed5cee7282e41167a1f4dfa23fb3acbbefc04d81bed7ec8f8b7c619015ae65#npm:10.1.4"],\
+          ["@swc/cli", "virtual:1d5ebb853d503e6fea373f31bf5c65a3d6b7a77f545a96c962e755e47337c3e496ed5cee7282e41167a1f4dfa23fb3acbbefc04d81bed7ec8f8b7c619015ae65#npm:0.4.0"],\
+          ["@swc/core", "virtual:1d5ebb853d503e6fea373f31bf5c65a3d6b7a77f545a96c962e755e47337c3e496ed5cee7282e41167a1f4dfa23fb3acbbefc04d81bed7ec8f8b7c619015ae65#npm:1.7.18"],\
+          ["@trpc/server", "npm:10.45.2"],\
+          ["@types/node", "npm:22.5.0"],\
+          ["chokidar", "npm:3.6.0"],\
+          ["fastify", "npm:5.0.0"],\
+          ["nestjs-trpc", "virtual:2bca6e3cbb4cd21ddce3b7d86d352a949459bf0520cd22c37c69c2f84be3cf6f50b3e9c7739215326a81a0a61eeba592973c9bca0bcdde30cfddd2e91303015d#workspace:packages/nestjs-trpc"],\
+          ["reflect-metadata", "npm:0.1.14"],\
+          ["rxjs", "npm:7.8.1"],\
+          ["trpc-panel", "virtual:1d5ebb853d503e6fea373f31bf5c65a3d6b7a77f545a96c962e755e47337c3e496ed5cee7282e41167a1f4dfa23fb3acbbefc04d81bed7ec8f8b7c619015ae65#npm:1.3.4"],\
+          ["ts-morph", "npm:23.0.0"],\
+          ["ts-node", "virtual:1d5ebb853d503e6fea373f31bf5c65a3d6b7a77f545a96c962e755e47337c3e496ed5cee7282e41167a1f4dfa23fb3acbbefc04d81bed7ec8f8b7c619015ae65#npm:10.9.2"],\
+          ["tsconfig-paths", "npm:4.2.0"],\
+          ["tslib", "npm:2.7.0"],\
+          ["typescript", "patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>::version=5.5.4&hash=379a07"],\
+          ["zod", "npm:3.23.8"]\
+        ],\
+        "linkType": "SOFT"\
+      }]\
+    ]],\
     ["execa", [\
       ["npm:0.7.0", {\
         "packageLocation": "../../.yarn/berry/cache/execa-npm-0.7.0-3f4e53d884-10c0.zip/node_modules/execa/",\
@@ -11897,6 +12121,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["fast-content-type-parse", [\
+      ["npm:1.1.0", {\
+        "packageLocation": "../../.yarn/berry/cache/fast-content-type-parse-npm-1.1.0-035173e566-10c0.zip/node_modules/fast-content-type-parse/",\
+        "packageDependencies": [\
+          ["fast-content-type-parse", "npm:1.1.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["fast-decode-uri-component", [\
       ["npm:1.0.1", {\
         "packageLocation": "../../.yarn/berry/cache/fast-decode-uri-component-npm-1.0.1-578ba9fecf-10c0.zip/node_modules/fast-decode-uri-component/",\
@@ -11948,6 +12181,20 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["fast-json-stringify", [\
+      ["npm:5.16.1", {\
+        "packageLocation": "../../.yarn/berry/cache/fast-json-stringify-npm-5.16.1-b77a4b7f73-10c0.zip/node_modules/fast-json-stringify/",\
+        "packageDependencies": [\
+          ["fast-json-stringify", "npm:5.16.1"],\
+          ["@fastify/merge-json-schemas", "npm:0.1.1"],\
+          ["ajv", "npm:8.17.1"],\
+          ["ajv-formats", "virtual:fef267081cdbabb1f4bf9bbf9fcaae65dbcff6d10275a8b7a2717546b9188fee5378783e3d901d136e65373026582350aa168c9fb29da1f6c445f545836b2fc6#npm:3.0.1"],\
+          ["fast-deep-equal", "npm:3.1.3"],\
+          ["fast-uri", "npm:2.4.0"],\
+          ["json-schema-ref-resolver", "npm:1.0.1"],\
+          ["rfdc", "npm:1.4.1"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["npm:6.0.0", {\
         "packageLocation": "../../.yarn/berry/cache/fast-json-stringify-npm-6.0.0-da1fe326b3-10c0.zip/node_modules/fast-json-stringify/",\
         "packageDependencies": [\
@@ -12024,6 +12271,29 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["fastify", [\
+      ["npm:4.28.1", {\
+        "packageLocation": "../../.yarn/berry/cache/fastify-npm-4.28.1-b5ef7d871c-10c0.zip/node_modules/fastify/",\
+        "packageDependencies": [\
+          ["fastify", "npm:4.28.1"],\
+          ["@fastify/ajv-compiler", "npm:3.6.0"],\
+          ["@fastify/error", "npm:3.4.1"],\
+          ["@fastify/fast-json-stringify-compiler", "npm:4.3.0"],\
+          ["abstract-logging", "npm:2.0.1"],\
+          ["avvio", "npm:8.4.0"],\
+          ["fast-content-type-parse", "npm:1.1.0"],\
+          ["fast-json-stringify", "npm:5.16.1"],\
+          ["find-my-way", "npm:8.2.2"],\
+          ["light-my-request", "npm:5.13.0"],\
+          ["pino", "npm:9.4.0"],\
+          ["process-warning", "npm:3.0.0"],\
+          ["proxy-addr", "npm:2.0.7"],\
+          ["rfdc", "npm:1.4.1"],\
+          ["secure-json-parse", "npm:2.7.0"],\
+          ["semver", "npm:7.6.3"],\
+          ["toad-cache", "npm:3.7.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["npm:5.0.0", {\
         "packageLocation": "../../.yarn/berry/cache/fastify-npm-5.0.0-068fe29859-10c0.zip/node_modules/fastify/",\
         "packageDependencies": [\
@@ -12043,6 +12313,15 @@ const RAW_RUNTIME_STATE =
           ["secure-json-parse", "npm:2.7.0"],\
           ["semver", "npm:7.6.3"],\
           ["toad-cache", "npm:3.7.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["fastify-plugin", [\
+      ["npm:4.5.1", {\
+        "packageLocation": "../../.yarn/berry/cache/fastify-plugin-npm-4.5.1-902caad25f-10c0.zip/node_modules/fastify-plugin/",\
+        "packageDependencies": [\
+          ["fastify-plugin", "npm:4.5.1"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -12168,6 +12447,16 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["find-my-way", [\
+      ["npm:8.2.2", {\
+        "packageLocation": "../../.yarn/berry/cache/find-my-way-npm-8.2.2-13991ee085-10c0.zip/node_modules/find-my-way/",\
+        "packageDependencies": [\
+          ["find-my-way", "npm:8.2.2"],\
+          ["fast-deep-equal", "npm:3.1.3"],\
+          ["fast-querystring", "npm:1.1.2"],\
+          ["safe-regex2", "npm:3.1.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["npm:9.1.0", {\
         "packageLocation": "../../.yarn/berry/cache/find-my-way-npm-9.1.0-0f4affcdb6-10c0.zip/node_modules/find-my-way/",\
         "packageDependencies": [\
@@ -15461,6 +15750,16 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["light-my-request", [\
+      ["npm:5.13.0", {\
+        "packageLocation": "../../.yarn/berry/cache/light-my-request-npm-5.13.0-3af0a4e344-10c0.zip/node_modules/light-my-request/",\
+        "packageDependencies": [\
+          ["light-my-request", "npm:5.13.0"],\
+          ["cookie", "npm:0.6.0"],\
+          ["process-warning", "npm:3.0.0"],\
+          ["set-cookie-parser", "npm:2.7.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["npm:6.0.0", {\
         "packageLocation": "../../.yarn/berry/cache/light-my-request-npm-6.0.0-cef4f96109-10c0.zip/node_modules/light-my-request/",\
         "packageDependencies": [\
@@ -17189,6 +17488,16 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["mnemonist", [\
+      ["npm:0.39.6", {\
+        "packageLocation": "../../.yarn/berry/cache/mnemonist-npm-0.39.6-a69a970c11-10c0.zip/node_modules/mnemonist/",\
+        "packageDependencies": [\
+          ["mnemonist", "npm:0.39.6"],\
+          ["obliterator", "npm:2.0.4"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["mri", [\
       ["npm:1.2.0", {\
         "packageLocation": "../../.yarn/berry/cache/mri-npm-1.2.0-8ecee0357d-10c0.zip/node_modules/mri/",\
@@ -17309,6 +17618,55 @@ const RAW_RUNTIME_STATE =
           ["@nestjs/common", "virtual:1d5ebb853d503e6fea373f31bf5c65a3d6b7a77f545a96c962e755e47337c3e496ed5cee7282e41167a1f4dfa23fb3acbbefc04d81bed7ec8f8b7c619015ae65#npm:10.4.1"],\
           ["@nestjs/core", "virtual:1d5ebb853d503e6fea373f31bf5c65a3d6b7a77f545a96c962e755e47337c3e496ed5cee7282e41167a1f4dfa23fb3acbbefc04d81bed7ec8f8b7c619015ae65#npm:10.4.1"],\
           ["@nestjs/testing", "virtual:fd4159eb197bcf91afbb9935b3186c9dc64c1c6787cc4471f7ca7924cdc400933f8d6e720e9281571c75ea4160cfb8c30d415db817a3e983f47336e4cce2d69a#npm:10.4.1"],\
+          ["@trpc/server", "npm:10.45.2"],\
+          ["@types/express", "npm:4.17.21"],\
+          ["@types/jest", "npm:29.5.12"],\
+          ["@types/lodash", "npm:4.17.7"],\
+          ["@types/nestjs__common", null],\
+          ["@types/nestjs__core", null],\
+          ["@types/node", "npm:22.5.0"],\
+          ["@types/reflect-metadata", null],\
+          ["@types/rxjs", null],\
+          ["@types/trpc__server", null],\
+          ["@types/zod", null],\
+          ["fastify", "npm:5.0.0"],\
+          ["func-loc", "npm:0.1.16"],\
+          ["jest", "virtual:e8c2026326350578d02b68ad535fd35e48f18c0982f4815fcbf4f100a889dce5bd7633118913a4c281bc0db311d4afa92fce0fce29e476de8880d9feed95eb0b#npm:29.7.0"],\
+          ["lodash", "npm:4.17.21"],\
+          ["reflect-metadata", "npm:0.1.14"],\
+          ["rxjs", "npm:7.8.1"],\
+          ["ts-jest", "virtual:fd4159eb197bcf91afbb9935b3186c9dc64c1c6787cc4471f7ca7924cdc400933f8d6e720e9281571c75ea4160cfb8c30d415db817a3e983f47336e4cce2d69a#npm:29.2.5"],\
+          ["ts-morph", "npm:22.0.0"],\
+          ["ts-node", "virtual:fd4159eb197bcf91afbb9935b3186c9dc64c1c6787cc4471f7ca7924cdc400933f8d6e720e9281571c75ea4160cfb8c30d415db817a3e983f47336e4cce2d69a#npm:10.9.2"],\
+          ["tsconfig-paths", "npm:4.2.0"],\
+          ["tslib", "npm:2.7.0"],\
+          ["type-fest", "npm:4.25.0"],\
+          ["typescript", "patch:typescript@npm%3A5.5.3#optional!builtin<compat/typescript>::version=5.5.3&hash=379a07"],\
+          ["zod", "npm:3.23.8"]\
+        ],\
+        "packagePeers": [\
+          "@nestjs/common",\
+          "@nestjs/core",\
+          "@trpc/server",\
+          "@types/nestjs__common",\
+          "@types/nestjs__core",\
+          "@types/reflect-metadata",\
+          "@types/rxjs",\
+          "@types/trpc__server",\
+          "@types/zod",\
+          "reflect-metadata",\
+          "rxjs",\
+          "zod"\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:2bca6e3cbb4cd21ddce3b7d86d352a949459bf0520cd22c37c69c2f84be3cf6f50b3e9c7739215326a81a0a61eeba592973c9bca0bcdde30cfddd2e91303015d#workspace:packages/nestjs-trpc", {\
+        "packageLocation": "./.yarn/__virtual__/nestjs-trpc-virtual-be79e81d01/1/packages/nestjs-trpc/",\
+        "packageDependencies": [\
+          ["nestjs-trpc", "virtual:2bca6e3cbb4cd21ddce3b7d86d352a949459bf0520cd22c37c69c2f84be3cf6f50b3e9c7739215326a81a0a61eeba592973c9bca0bcdde30cfddd2e91303015d#workspace:packages/nestjs-trpc"],\
+          ["@nestjs/common", "virtual:1d5ebb853d503e6fea373f31bf5c65a3d6b7a77f545a96c962e755e47337c3e496ed5cee7282e41167a1f4dfa23fb3acbbefc04d81bed7ec8f8b7c619015ae65#npm:10.4.1"],\
+          ["@nestjs/core", "virtual:2bca6e3cbb4cd21ddce3b7d86d352a949459bf0520cd22c37c69c2f84be3cf6f50b3e9c7739215326a81a0a61eeba592973c9bca0bcdde30cfddd2e91303015d#npm:10.4.1"],\
+          ["@nestjs/testing", "virtual:be79e81d01e86a010006ee71d7112b5a7c2871f4c93ebdf7486ab7900046d396459596f12aa8e76a6c189f0c76843b655ef596ef474d45878137d5dcd77b6028#npm:10.4.1"],\
           ["@trpc/server", "npm:10.45.2"],\
           ["@types/express", "npm:4.17.21"],\
           ["@types/jest", "npm:29.5.12"],\
@@ -18155,6 +18513,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["obliterator", [\
+      ["npm:2.0.4", {\
+        "packageLocation": "../../.yarn/berry/cache/obliterator-npm-2.0.4-b21b355294-10c0.zip/node_modules/obliterator/",\
+        "packageDependencies": [\
+          ["obliterator", "npm:2.0.4"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["on-exit-leak-free", [\
       ["npm:2.1.2", {\
         "packageLocation": "../../.yarn/berry/cache/on-exit-leak-free-npm-2.1.2-0d0c5ad67d-10c0.zip/node_modules/on-exit-leak-free/",\
@@ -18687,6 +19054,20 @@ const RAW_RUNTIME_STATE =
           ["path-to-regexp", "npm:3.2.0"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:3.3.0", {\
+        "packageLocation": "../../.yarn/berry/cache/path-to-regexp-npm-3.3.0-67764d7b0a-10c0.zip/node_modules/path-to-regexp/",\
+        "packageDependencies": [\
+          ["path-to-regexp", "npm:3.3.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:6.3.0", {\
+        "packageLocation": "../../.yarn/berry/cache/path-to-regexp-npm-6.3.0-ee2cdde576-10c0.zip/node_modules/path-to-regexp/",\
+        "packageDependencies": [\
+          ["path-to-regexp", "npm:6.3.0"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["path-type", [\
@@ -19094,6 +19475,13 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["process-warning", [\
+      ["npm:3.0.0", {\
+        "packageLocation": "../../.yarn/berry/cache/process-warning-npm-3.0.0-e1380c08e2-10c0.zip/node_modules/process-warning/",\
+        "packageDependencies": [\
+          ["process-warning", "npm:3.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["npm:4.0.0", {\
         "packageLocation": "../../.yarn/berry/cache/process-warning-npm-4.0.0-d61ed74d22-10c0.zip/node_modules/process-warning/",\
         "packageDependencies": [\
@@ -20023,6 +20411,13 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["ret", [\
+      ["npm:0.4.3", {\
+        "packageLocation": "../../.yarn/berry/cache/ret-npm-0.4.3-0ce635a7e4-10c0.zip/node_modules/ret/",\
+        "packageDependencies": [\
+          ["ret", "npm:0.4.3"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["npm:0.5.0", {\
         "packageLocation": "../../.yarn/berry/cache/ret-npm-0.5.0-80249185b8-10c0.zip/node_modules/ret/",\
         "packageDependencies": [\
@@ -20199,6 +20594,14 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["safe-regex2", [\
+      ["npm:3.1.0", {\
+        "packageLocation": "../../.yarn/berry/cache/safe-regex2-npm-3.1.0-c21f2e8fbd-10c0.zip/node_modules/safe-regex2/",\
+        "packageDependencies": [\
+          ["safe-regex2", "npm:3.1.0"],\
+          ["ret", "npm:0.4.3"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["npm:4.0.0", {\
         "packageLocation": "../../.yarn/berry/cache/safe-regex2-npm-4.0.0-e09ce0e704-10c0.zip/node_modules/safe-regex2/",\
         "packageDependencies": [\

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 - ⚡️&nbsp; Same client-side DX - We generate the AppRouter on the fly.
 - 🔋&nbsp; Examples are available in the ./examples folder.
 - 📦&nbsp; Out of the box support for **Dependency Injection** within the routes and procedures.
-- 👀&nbsp; Native support for `express`, and `zod` with more drivers to come!
+- 👀&nbsp; Native support for `express`, `fastify`, and `zod` with more drivers to come!
 
 ## Quickstart
 

--- a/docs/pages/docs/client.mdx
+++ b/docs/pages/docs/client.mdx
@@ -82,7 +82,7 @@ Here is and example for a router, and the generated output:
 </Tabs>
 
 The generated AppRouter is **only used for type inference**, thats why you don't see any logic within `.query(){:tsx}` method and why we have a `'PLACEHOLDER_DO_NOT_REMOVE' as any{:tsx}` as the logic just to keep typescript happy. 
-Your router business logic is then executed during run-time with vanilla trpc and the selected driver (`express` or `fastify`) based on your configurations.
+Your router business logic is then executed during run-time with vanilla trpc and the selected driver (either `express` or `fastify`) based on your configurations.
 
 <Callout>
     If you notice the generated `AppRouter` takes into concideration the `@Router(alias?: string){:tsx}` alias, and it hoists the original `ZodSchema` even if imported from a different file (which wasn't easy to make work 😅).

--- a/docs/pages/docs/context.mdx
+++ b/docs/pages/docs/context.mdx
@@ -25,14 +25,14 @@ Setting up the context can be done in 3 steps, defining the context class, regis
   To define a new context, we need to create a class that implements `TRPCContext` and it's method `create(){:tsx}`.
   ```typescript filename="app.context.ts" copy
   import { Inject, Injectable } from '@nestjs/common';
-  import { ExpressContextOptions, TRPCContext } from 'nestjs-trpc';
+  import { ContextOptions, TRPCContext } from 'nestjs-trpc';
   import { InnerContext } from './inner.context';
 
   @Injectable()
   export class AppContext implements TRPCContext {
     constructor(@Inject(InnerContext) private readonly innerContext: InnerContext){}
 
-    async create(opts: ExpressContextOptions): Promise<Record<string, unknown>> {
+    async create(opts: ContextOptions): Promise<Record<string, unknown>> {
       const contextInner = await this.innerContext.create(opts);
       return {
         ...contextInner,
@@ -80,11 +80,11 @@ You can import this type and use throughout your middlewares and procedures from
   <Tabs.Tab>
   ```typescript filename="app.context.ts" copy
   import { Injectable } from '@nestjs/common';
-  import { ExpressContextOptions, TRPCContext } from 'nestjs-trpc';
+  import { ContextOptions, TRPCContext } from 'nestjs-trpc';
 
   @Injectable()
   export class AppContext implements TRPCContext {
-    create(opts: ExpressContextOptions): Record<string, unknown> {
+    create(opts: ContextOptions): Record<string, unknown> {
       return {
         isContextApplied: true,
       };

--- a/docs/pages/docs/index.mdx
+++ b/docs/pages/docs/index.mdx
@@ -58,7 +58,7 @@ import { TRPCModule } from 'nestjs-trpc';
 export class AppModule {}
 ```
 
-The `forRoot()` method takes an options object as an argument. These options are passed through to the underlying express driver. For example, if you want to disable the schema file generation (when deploying to production), you can omit the `autoSchemaFile` option.
+The `forRoot()` method takes an options object as an argument. These options are passed through to the underlying `express` or `fastify` driver. For example, if you want to disable the schema file generation (when deploying to production), you can omit the `autoSchemaFile` option.
 
 ### Start your NestJS server. You should be good to go! 🎉
 

--- a/docs/pages/docs/structure.mdx
+++ b/docs/pages/docs/structure.mdx
@@ -53,4 +53,4 @@ Here's a brief overview of those core files:
 </Table>
 
 ### Platform
-As of writing, we only have support for the `expressjs` driver, while we continue working on the `fastify` driver.
+As of writing, we have native support for both the `express` and the `fastify` drivers, the adapter checks which driver you are currently using and adapts accordingly.

--- a/examples/nestjs-express/src/app.context.ts
+++ b/examples/nestjs-express/src/app.context.ts
@@ -1,12 +1,12 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { ExpressContextOptions, TRPCContext } from 'nestjs-trpc';
+import { ContextOptions, TRPCContext } from 'nestjs-trpc';
 import { UserService } from './user.service';
 
 @Injectable()
 export class AppContext implements TRPCContext {
   constructor(@Inject(UserService) private readonly userService: UserService) {}
 
-  async create(opts: ExpressContextOptions): Promise<Record<string, unknown>> {
+  async create(opts: ContextOptions): Promise<Record<string, unknown>> {
     const res = await this.userService.test();
     return {
       req: opts.req,

--- a/examples/nestjs-fastify/.gitignore
+++ b/examples/nestjs-fastify/.gitignore
@@ -1,0 +1,25 @@
+# dependencies
+node_modules
+
+# IDE
+/.idea
+/.vscode
+
+# misc
+npm-debug.log
+.DS_Store
+
+# examples
+/test
+/coverage
+/.nyc_output
+test-schema.graphql
+*.test-definitions.ts
+
+# dist
+dist
+**/*.tsbuildinfo
+
+.yarn/
+
+src/@generated

--- a/examples/nestjs-fastify/nest-cli.json
+++ b/examples/nestjs-fastify/nest-cli.json
@@ -1,0 +1,16 @@
+{
+  "language": "ts",
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src",
+  "compilerOptions": {
+    "deleteOutDir": true
+  },
+  "watchOptions": {
+    "watchExclude": [
+      "src/@generated/**/*",
+      "src/@generated/*",
+      "**/@generated/**/*",
+      "**/*.spec.ts"
+    ]
+  }
+}

--- a/examples/nestjs-fastify/package.json
+++ b/examples/nestjs-fastify/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "example-nestjs-fastify",
+  "version": "1.0.0",
+  "description": "",
+  "main": "./src/main.ts",
+  "scripts": {
+    "build": "nest build",
+    "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "start": "nest start",
+    "start:dev": "nest start --watch --preserveWatchOutput",
+    "start:debug": "nest start --debug --watch --preserveWatchOutput",
+    "start:prod": "node dist/main"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@nestjs/common": "10.4.1",
+    "@nestjs/config": "^3.0.0",
+    "@nestjs/core": "10.4.1",
+    "@nestjs/platform-fastify": "^10.4.4",
+    "@trpc/server": "^10.33.0",
+    "fastify": "^5.0.0",
+    "nestjs-trpc": "workspace:*",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.2.0",
+    "zod": "^3.21.4"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "10.4.4",
+    "@nestjs/schematics": "^10.1.2",
+    "@swc/cli": "^0.4.0",
+    "@swc/core": "^1.7.18",
+    "@types/node": "^22.5.0",
+    "chokidar": "^3.6.0",
+    "trpc-panel": "^1.3.4",
+    "ts-morph": "^23.0.0",
+    "ts-node": "^10.9.1",
+    "tsconfig-paths": "^4.2.0",
+    "tslib": "^2.5.0",
+    "typescript": "^5.0.3"
+  }
+}

--- a/examples/nestjs-fastify/src/app.context.ts
+++ b/examples/nestjs-fastify/src/app.context.ts
@@ -1,0 +1,18 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ContextOptions, TRPCContext } from 'nestjs-trpc';
+import { UserService } from './user.service';
+
+@Injectable()
+export class AppContext implements TRPCContext {
+  constructor(@Inject(UserService) private readonly userService: UserService) {}
+
+  async create(opts: ContextOptions): Promise<Record<string, unknown>> {
+    const res = await this.userService.test();
+    return {
+      req: opts.req,
+      auth: {
+        user: res,
+      },
+    };
+  }
+}

--- a/examples/nestjs-fastify/src/app.module.ts
+++ b/examples/nestjs-fastify/src/app.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { UserRouter } from './user.router';
+import { TRPCModule } from 'nestjs-trpc';
+import { UserService } from './user.service';
+import { ProtectedMiddleware } from './protected.middleware';
+import { AppContext } from './app.context';
+import { TrpcPanelController } from './trpc-panel.controller';
+
+@Module({
+  imports: [
+    TRPCModule.forRoot({
+      autoSchemaFile: './src/@generated',
+      context: AppContext,
+    }),
+  ],
+  controllers: [TrpcPanelController],
+  providers: [UserRouter, AppContext, UserService, ProtectedMiddleware],
+})
+export class AppModule {}

--- a/examples/nestjs-fastify/src/main.ts
+++ b/examples/nestjs-fastify/src/main.ts
@@ -1,0 +1,18 @@
+import { NestFactory } from '@nestjs/core';
+import {
+  FastifyAdapter,
+  NestFastifyApplication,
+} from '@nestjs/platform-fastify';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create<NestFastifyApplication>(
+    AppModule,
+    new FastifyAdapter(),
+    { cors: true },
+  );
+
+  await app.listen(8080);
+}
+
+void bootstrap();

--- a/examples/nestjs-fastify/src/protected.middleware.ts
+++ b/examples/nestjs-fastify/src/protected.middleware.ts
@@ -1,0 +1,27 @@
+import {
+  MiddlewareOptions,
+  MiddlewareResponse,
+  TRPCMiddleware,
+} from 'nestjs-trpc';
+import { Inject, Injectable } from '@nestjs/common';
+import { UserService } from './user.service';
+
+@Injectable()
+export class ProtectedMiddleware implements TRPCMiddleware {
+  constructor(@Inject(UserService) private readonly userService: UserService) {}
+  async use(opts: MiddlewareOptions<object>): Promise<MiddlewareResponse> {
+    const start = Date.now();
+    const result = await opts.next({
+      ctx: {
+        ben: 1,
+      },
+    });
+
+    const durationMs = Date.now() - start;
+    const meta = { path: opts.path, type: opts.type, durationMs };
+    result.ok
+      ? console.log('OK request timing:', meta)
+      : console.error('Non-OK request timing', meta);
+    return result;
+  }
+}

--- a/examples/nestjs-fastify/src/trpc-panel.controller.ts
+++ b/examples/nestjs-fastify/src/trpc-panel.controller.ts
@@ -1,0 +1,33 @@
+import {
+  All,
+  Controller,
+  Inject,
+  OnModuleInit,
+  Response,
+} from '@nestjs/common';
+import { renderTrpcPanel } from 'trpc-panel';
+import type { AnyRouter } from '@trpc/server';
+import { AppRouterHost } from 'nestjs-trpc';
+import type { FastifyReply } from 'fastify';
+
+@Controller()
+export class TrpcPanelController implements OnModuleInit {
+  private appRouter!: AnyRouter;
+
+  constructor(
+    @Inject(AppRouterHost) private readonly appRouterHost: AppRouterHost,
+  ) {}
+
+  onModuleInit() {
+    this.appRouter = this.appRouterHost.appRouter;
+  }
+
+  @All('/panel')
+  panel(@Response() res: FastifyReply) {
+    res.type('text/html').send(
+      renderTrpcPanel(this.appRouter, {
+        url: 'http://localhost:8080/trpc',
+      }),
+    );
+  }
+}

--- a/examples/nestjs-fastify/src/user.controller.ts
+++ b/examples/nestjs-fastify/src/user.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Get, Post } from '@nestjs/common';
+
+@Controller('cats')
+export class CatsController {
+  @Get()
+  findAll(): string {
+    return 'This action returns all cats';
+  }
+
+  @Post()
+  findPAll(): string {
+    return 'This action returns all cats';
+  }
+
+  @Post('bla')
+  returnBla() {
+    return 'This action returns all cats';
+  }
+}

--- a/examples/nestjs-fastify/src/user.router.ts
+++ b/examples/nestjs-fastify/src/user.router.ts
@@ -1,0 +1,42 @@
+import { Inject } from '@nestjs/common';
+import {
+  Router,
+  Query,
+  Middlewares,
+  Input,
+  Ctx,
+  Options,
+  ProcedureOptions,
+} from 'nestjs-trpc';
+import { UserService } from './user.service';
+import { ProtectedMiddleware } from './protected.middleware';
+import { z } from 'zod';
+import { TRPCError } from '@trpc/server';
+import { User, userSchema } from './user.schema';
+
+@Router({ alias: 'users' })
+export class UserRouter {
+  constructor(@Inject(UserService) private readonly userService: UserService) {}
+
+  @Query({
+    input: z.object({ userId: z.string() }),
+    output: userSchema,
+  })
+  @Middlewares(ProtectedMiddleware)
+  async getUserById(
+    @Input('userId') userId: string,
+    @Ctx() ctx: object,
+    @Options() opts: ProcedureOptions,
+  ): Promise<User> {
+    const user = await this.userService.getUser(userId);
+
+    if (!ctx) {
+      throw new TRPCError({
+        message: 'Could not find user.',
+        code: 'NOT_FOUND',
+      });
+    }
+
+    return user;
+  }
+}

--- a/examples/nestjs-fastify/src/user.schema.ts
+++ b/examples/nestjs-fastify/src/user.schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const userSchema = z.object({
+  name: z.string(),
+  email: z.string(),
+  password: z.string(),
+});
+
+export type User = z.infer<typeof userSchema>;

--- a/examples/nestjs-fastify/src/user.service.ts
+++ b/examples/nestjs-fastify/src/user.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { User } from './user.schema';
+
+@Injectable()
+export class UserService {
+  async test(): Promise<string> {
+    return 'test';
+  }
+
+  async getUser(userId: string): Promise<User> {
+    return {
+      name: 'user',
+      email: 'user@email.com',
+      password: '0000',
+    };
+  }
+}

--- a/examples/nestjs-fastify/tsconfig.build.json
+++ b/examples/nestjs-fastify/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "exclude": ["node_modules", "dist", "src/**/__tests__/*", "*.spec.ts"]
+}

--- a/examples/nestjs-fastify/tsconfig.json
+++ b/examples/nestjs-fastify/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.build.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.build.json"
+    }
+  ]
+}

--- a/packages/nestjs-trpc/lib/drivers/express.driver.ts
+++ b/packages/nestjs-trpc/lib/drivers/express.driver.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import type { Application as ExpressApplication } from 'express';
+import { TRPCContext, TRPCModuleOptions } from '../interfaces';
+import type { AnyRouter } from '@trpc/server';
+import * as trpcExpress from '@trpc/server/adapters/express';
+
+@Injectable()
+export class ExpressDriver<
+  TOptions extends Record<string, any> = TRPCModuleOptions,
+> {
+  public async start(
+    options: TRPCModuleOptions,
+    app: ExpressApplication,
+    appRouter: AnyRouter,
+    contextInstance: TRPCContext | null,
+  ) {
+    app.use(
+      options.basePath ?? '/trpc',
+      trpcExpress.createExpressMiddleware({
+        router: appRouter,
+        ...(options.context != null && contextInstance != null
+          ? {
+              createContext: (opts) => contextInstance.create(opts),
+            }
+          : {}),
+      }),
+    );
+  }
+}

--- a/packages/nestjs-trpc/lib/drivers/fastify.driver.ts
+++ b/packages/nestjs-trpc/lib/drivers/fastify.driver.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import type { FastifyInstance as FastifyApplication } from 'fastify';
+import { ContextOptions, TRPCContext, TRPCModuleOptions } from '../interfaces';
+import type { AnyRouter } from '@trpc/server';
+import * as trpcFastify from '@trpc/server/adapters/fastify';
+
+@Injectable()
+export class FastifyDriver<
+  TOptions extends Record<string, any> = TRPCModuleOptions,
+> {
+  public async start(
+    options: TRPCModuleOptions,
+    app: FastifyApplication,
+    appRouter: AnyRouter,
+    contextInstance: TRPCContext | null,
+  ) {
+    app.register(trpcFastify.fastifyTRPCPlugin, {
+      prefix: options.basePath ?? '/trpc',
+      trpcOptions: {
+        router: appRouter,
+        ...(options.context != null && contextInstance != null
+          ? {
+              createContext: (opts: ContextOptions) =>
+                contextInstance.create(opts),
+            }
+          : {}),
+      },
+    });
+  }
+}

--- a/packages/nestjs-trpc/lib/drivers/index.ts
+++ b/packages/nestjs-trpc/lib/drivers/index.ts
@@ -1,0 +1,2 @@
+export * from './fastify.driver';
+export * from './express.driver';

--- a/packages/nestjs-trpc/lib/interfaces/context.interface.ts
+++ b/packages/nestjs-trpc/lib/interfaces/context.interface.ts
@@ -1,9 +1,12 @@
 import type { CreateExpressContextOptions } from '@trpc/server/adapters/express';
+import type { CreateFastifyContextOptions } from '@trpc/server/adapters/fastify';
 
-export type ExpressContextOptions = CreateExpressContextOptions;
+export type ContextOptions =
+  | CreateExpressContextOptions
+  | CreateFastifyContextOptions;
 
 export interface TRPCContext {
   create(
-    opts: ExpressContextOptions,
+    opts: ContextOptions,
   ): Record<string, unknown> | Promise<Record<string, unknown>>;
 }

--- a/packages/nestjs-trpc/lib/interfaces/factory.interface.ts
+++ b/packages/nestjs-trpc/lib/interfaces/factory.interface.ts
@@ -1,16 +1,10 @@
 import type {
   ProcedureRouterRecord,
   AnyRouter,
-  AnyRootConfig,
   ProcedureBuilder,
-  RootConfig,
-  DataTransformerOptions,
-  unsetMarker,
   ProcedureType,
-  Router,
   ProcedureParams,
 } from '@trpc/server';
-import type { RouterDef } from '@trpc/server/dist/core/router';
 import type { ZodSchema, ZodType, ZodTypeDef } from 'zod';
 import type { TRPCMiddleware } from './middleware.interface';
 import type { Class } from 'type-fest';
@@ -78,15 +72,5 @@ export interface RoutersFactoryMetadata {
 export type TRPCRouter = <TProcRouterRecord extends ProcedureRouterRecord>(
   procedures: TProcRouterRecord,
 ) => AnyRouter;
-
-export type TRPCMergeRoutes = <TRouters extends AnyRouter[]>(
-  ...routerList_0: TRouters
-) => Router<
-  RouterDef<
-    AnyRootConfig,
-    {},
-    { queries: {}; mutations: {}; subscriptions: {} }
-  >
->;
 
 export type TRPCPublicProcedure = ProcedureBuilder<ProcedureParams>;

--- a/packages/nestjs-trpc/lib/interfaces/middleware.interface.ts
+++ b/packages/nestjs-trpc/lib/interfaces/middleware.interface.ts
@@ -1,9 +1,5 @@
-import type {
-  ProcedureType,
-  ProcedureParams,
-} from '@trpc/server';
+import type { ProcedureType, ProcedureParams } from '@trpc/server';
 import type { MiddlewareResult } from '@trpc/server/dist/core/middleware';
-
 
 export type MiddlewareResponse =
   | Promise<MiddlewareResult<ProcedureParams>>

--- a/packages/nestjs-trpc/lib/interfaces/module-options.interface.ts
+++ b/packages/nestjs-trpc/lib/interfaces/module-options.interface.ts
@@ -1,4 +1,3 @@
-import type { CreateExpressContextOptions } from '@trpc/server/adapters/express';
 import { RootConfigTypes } from '@trpc/server/dist/core/internals/config';
 import { ErrorFormatter } from '@trpc/server/dist/error/formatter';
 import { TRPCErrorShape } from '@trpc/server/dist/rpc';
@@ -21,7 +20,7 @@ export interface TRPCModuleOptions {
   basePath?: string;
 
   /**
-   * The exposed trpc options when creating a route with `createExpressMiddleware`.
+   * The exposed trpc options when creating a route with either `createExpressMiddleware` or `createFastifyMiddleware`.
    * If not provided, the adapter will use a default createContext.
    * @link https://nestjs-trpc.io/docs/context
    */

--- a/packages/nestjs-trpc/lib/interfaces/procedure-options.interface.ts
+++ b/packages/nestjs-trpc/lib/interfaces/procedure-options.interface.ts
@@ -1,8 +1,8 @@
-import { DataTransformerOptions, ProcedureBuilder, ProcedureParams, RootConfig } from '@trpc/server';
+import { ProcedureParams } from '@trpc/server';
 import { ResolveOptions } from '@trpc/server/dist/core/internals/utils';
 
 export type ProcedureOptions = ResolveOptions<ProcedureParams> & {
-    type: string;
-    path: string;
-    rawInput: string;
+  type: string;
+  path: string;
+  rawInput: string;
 };

--- a/packages/nestjs-trpc/lib/trpc.driver.ts
+++ b/packages/nestjs-trpc/lib/trpc.driver.ts
@@ -1,12 +1,34 @@
 import { ConsoleLogger, Inject, Injectable, Type } from '@nestjs/common';
 import { HttpAdapterHost, ModuleRef } from '@nestjs/core';
 import type { Application as ExpressApplication } from 'express';
+import type { FastifyInstance as FastifyApplication } from 'fastify';
 import { TRPCContext, TRPCModuleOptions } from './interfaces';
 import { AnyRouter, initTRPC } from '@trpc/server';
-import * as trpcExpress from '@trpc/server/adapters/express';
 import { TRPCFactory } from './factories/trpc.factory';
 import { TRPCGenerator } from './generators/trpc.generator';
 import { AppRouterHost } from './app-router.host';
+import { ExpressDriver, FastifyDriver } from './drivers';
+
+function isExpressApplication(app: any): app is ExpressApplication {
+  return (
+    typeof app === 'function' &&
+    typeof app.get === 'function' &&
+    typeof app.post === 'function' &&
+    typeof app.use === 'function' &&
+    typeof app.listen === 'function'
+  );
+}
+
+function isFastifyApplication(app: any): app is FastifyApplication {
+  return (
+    typeof app === 'object' &&
+    app !== null &&
+    typeof app.get === 'function' &&
+    typeof app.post === 'function' &&
+    typeof app.register === 'function' &&
+    typeof app.listen === 'function'
+  );
+}
 
 @Injectable()
 export class TRPCDriver<
@@ -27,19 +49,15 @@ export class TRPCDriver<
   @Inject(AppRouterHost)
   protected readonly appRouterHost!: AppRouterHost;
 
+  @Inject(ExpressDriver)
+  protected readonly expressDriver!: ExpressDriver;
+
+  @Inject(FastifyDriver)
+  protected readonly fastifyDriver!: FastifyDriver;
+
   constructor(private moduleRef: ModuleRef) {}
 
   public async start(options: TRPCModuleOptions) {
-    const { httpAdapter } = this.httpAdapterHost;
-    const platformName = httpAdapter.getType();
-
-    if (platformName !== 'express') {
-      //TODO: Add support for Fastify through different drivers
-      throw new Error(`No support for current HttpAdapter: ${platformName}`);
-    }
-
-    const app = httpAdapter.getInstance<ExpressApplication>();
-
     //@ts-expect-error Ignoring typescript here since it's the same type, yet it still isn't able to infer it.
     const { procedure, router } = initTRPC.context().create({
       ...(options.transformer != null
@@ -63,17 +81,20 @@ export class TRPCDriver<
           })
         : null;
 
-    app.use(
-      options.basePath ?? '/trpc',
-      trpcExpress.createExpressMiddleware({
-        router: appRouter,
-        ...(options.context != null && contextInstance != null
-          ? {
-              createContext: (opts) => contextInstance.create(opts),
-            }
-          : {}),
-      }),
-    );
+    const { httpAdapter } = this.httpAdapterHost;
+    const platformName = httpAdapter.getType();
+
+    const app = httpAdapter.getInstance<
+      ExpressApplication | FastifyApplication
+    >();
+
+    if (platformName === 'express' && isExpressApplication(app)) {
+      await this.expressDriver.start(options, app, appRouter, contextInstance);
+    } else if (platformName === 'fastify' && isFastifyApplication(app)) {
+      await this.fastifyDriver.start(options, app, appRouter, contextInstance);
+    } else {
+      throw new Error(`Unsupported http adapter: ${platformName}`);
+    }
 
     if (options.autoSchemaFile != null) {
       await this.trpcGenerator.generateSchemaFile(options.autoSchemaFile);

--- a/packages/nestjs-trpc/lib/trpc.module.ts
+++ b/packages/nestjs-trpc/lib/trpc.module.ts
@@ -19,6 +19,7 @@ import { RouterGenerator } from './generators/router.generator';
 import { MiddlewareGenerator } from './generators/middleware.generator';
 import { ContextGenerator } from './generators/context.generator';
 import { AppRouterHost } from './app-router.host';
+import { ExpressDriver, FastifyDriver } from './drivers';
 
 @Module({
   imports: [],
@@ -36,6 +37,8 @@ import { AppRouterHost } from './app-router.host';
     RouterGenerator,
     TRPCGenerator,
     AppRouterHost,
+    FastifyDriver,
+    ExpressDriver,
   ],
   exports: [AppRouterHost],
 })
@@ -69,13 +72,14 @@ export class TRPCModule implements OnModuleInit {
     if (!httpAdapter) {
       return;
     }
-
     this.consoleLogger.setContext(LOGGER_CONTEXT);
+
     await this.trpcDriver.start(this.options);
 
+    const platformName = httpAdapter.getType();
     if (this.appRouterHost.appRouter != null) {
       this.consoleLogger.log(
-        'Server has been initialized successfully.',
+        `Server has been initialized successfully using the ${platformName} driver.`,
         'TRPC Server',
       );
     }

--- a/packages/nestjs-trpc/package.json
+++ b/packages/nestjs-trpc/package.json
@@ -6,8 +6,7 @@
   "types": "./lib/index.ts",
   "license": "MIT",
   "files": [
-    "dist",
-    "lib"
+    "dist"
   ],
   "exports": {
     ".": {
@@ -56,6 +55,7 @@
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.17.5",
     "@types/node": "^22.5.0",
+    "fastify": "^5.0.0",
     "jest": "^29.7.0",
     "reflect-metadata": "0.1.13",
     "rxjs": "7.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1901,6 +1901,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@fastify/ajv-compiler@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "@fastify/ajv-compiler@npm:4.0.1"
+  dependencies:
+    ajv: "npm:^8.12.0"
+    ajv-formats: "npm:^3.0.1"
+    fast-uri: "npm:^3.0.0"
+  checksum: 10c0/178d06e799e6ea19d4b579cc90e11ef50babda9fc2828d85edbd7b08aaa5a63dad2a42ba92e07e9c1e5da78e4382854bb1e99a6f2f5e61da67c670dc3572842e
+  languageName: node
+  linkType: hard
+
+"@fastify/error@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@fastify/error@npm:4.0.0"
+  checksum: 10c0/074b8a6c350c29a8fc8314298d9457fe0c1ba6e7f160e9ae6ba0e18853f1ec7427d768f966700cbf67a4694f3a9a593c6a23e42ce3ed62e40fecdf8026040d9a
+  languageName: node
+  linkType: hard
+
+"@fastify/fast-json-stringify-compiler@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "@fastify/fast-json-stringify-compiler@npm:5.0.1"
+  dependencies:
+    fast-json-stringify: "npm:^6.0.0"
+  checksum: 10c0/dc294c24684fe900b9190f3b4d8e52b6438bf9e737dbd2b3b202d906f71ef1fb406c031c40fc34f52c61f4f00e1a0d5753ce5a88064de371248fb4116c02066b
+  languageName: node
+  linkType: hard
+
+"@fastify/merge-json-schemas@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "@fastify/merge-json-schemas@npm:0.1.1"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.3"
+  checksum: 10c0/7979ce12724f7b98aea06f0bb9afb20dd869f0ff6fc697517135cbb54e0a36b062cbb38ec176fe43d1fc455576839240df8f33533939ace2d64a6218a6e6b9c1
+  languageName: node
+  linkType: hard
+
 "@headlessui/react@npm:^1.7.17":
   version: 1.7.19
   resolution: "@headlessui/react@npm:1.7.19"
@@ -4604,6 +4640,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"abort-controller@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "abort-controller@npm:3.0.0"
+  dependencies:
+    event-target-shim: "npm:^5.0.0"
+  checksum: 10c0/90ccc50f010250152509a344eb2e71977fbf8db0ab8f1061197e3275ddf6c61a41a6edfd7b9409c664513131dd96e962065415325ef23efa5db931b382d24ca5
+  languageName: node
+  linkType: hard
+
+"abstract-logging@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "abstract-logging@npm:2.0.1"
+  checksum: 10c0/304879d9babcf6772260e5ddde632e6428e1f42f7a7a116d4689e97ad813a20e0ec2dd1e0a122f3617557f40091b9ca85735de4b48c17a2041268cb47b3f8ef1
+  languageName: node
+  linkType: hard
+
 "accepts@npm:~1.3.8":
   version: 1.3.8
   resolution: "accepts@npm:1.3.8"
@@ -4699,6 +4751,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ajv-formats@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "ajv-formats@npm:3.0.1"
+  dependencies:
+    ajv: "npm:^8.0.0"
+  peerDependencies:
+    ajv: ^8.0.0
+  peerDependenciesMeta:
+    ajv:
+      optional: true
+  checksum: 10c0/168d6bca1ea9f163b41c8147bae537e67bd963357a5488a1eaf3abe8baa8eec806d4e45f15b10767e6020679315c7e1e5e6803088dfb84efa2b4e9353b83dd0a
+  languageName: node
+  linkType: hard
+
 "ajv-keywords@npm:^3.5.2":
   version: 3.5.2
   resolution: "ajv-keywords@npm:3.5.2"
@@ -4732,7 +4798,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^8.0.0, ajv@npm:^8.11.0":
+"ajv@npm:^8.0.0, ajv@npm:^8.11.0, ajv@npm:^8.12.0":
   version: 8.17.1
   resolution: "ajv@npm:8.17.1"
   dependencies:
@@ -5096,6 +5162,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"atomic-sleep@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "atomic-sleep@npm:1.0.0"
+  checksum: 10c0/e329a6665512736a9bbb073e1761b4ec102f7926cce35037753146a9db9c8104f5044c1662e4a863576ce544fb8be27cd2be6bc8c1a40147d03f31eb1cfb6e8a
+  languageName: node
+  linkType: hard
+
 "autoprefixer@npm:10.4.14":
   version: 10.4.14
   resolution: "autoprefixer@npm:10.4.14"
@@ -5138,6 +5211,16 @@ __metadata:
   dependencies:
     possible-typed-array-names: "npm:^1.0.0"
   checksum: 10c0/d07226ef4f87daa01bd0fe80f8f310982e345f372926da2e5296aecc25c41cab440916bbaa4c5e1034b453af3392f67df5961124e4b586df1e99793a1374bdb2
+  languageName: node
+  linkType: hard
+
+"avvio@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "avvio@npm:9.0.0"
+  dependencies:
+    "@fastify/error": "npm:^4.0.0"
+    fastq: "npm:^1.17.1"
+  checksum: 10c0/d44527023141b330fc6ded974ad13cd1144b03471a1f136beb03525aff9f1c1721b963ef0f9c2906536367b14dcd41fffcadef8bae2786ae29ab4216c3092cf9
   languageName: node
   linkType: hard
 
@@ -5473,6 +5556,16 @@ __metadata:
     base64-js: "npm:^1.3.1"
     ieee754: "npm:^1.1.13"
   checksum: 10c0/27cac81cff434ed2876058d72e7c4789d11ff1120ef32c9de48f59eab58179b66710c488987d295ae89a228f835fc66d088652dffeb8e3ba8659f80eb091d55e
+  languageName: node
+  linkType: hard
+
+"buffer@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "buffer@npm:6.0.3"
+  dependencies:
+    base64-js: "npm:^1.3.1"
+    ieee754: "npm:^1.2.1"
+  checksum: 10c0/2a905fbbcde73cc5d8bd18d1caa23715d5f83a5935867c2329f0ac06104204ba7947be098fe1317fbd8830e26090ff8e764f08cd14fefc977bb248c3487bcbd0
   languageName: node
   linkType: hard
 
@@ -6321,7 +6414,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:0.6.0":
+"cookie@npm:0.6.0, cookie@npm:^0.6.0":
   version: 0.6.0
   resolution: "cookie@npm:0.6.0"
   checksum: 10c0/f2318b31af7a31b4ddb4a678d024514df5e705f9be5909a192d7f116cfb6d45cbacf96a473fa733faa95050e7cff26e7832bb3ef94751592f1387b71c8956686
@@ -8204,6 +8297,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"event-target-shim@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "event-target-shim@npm:5.0.1"
+  checksum: 10c0/0255d9f936215fd206156fd4caa9e8d35e62075d720dc7d847e89b417e5e62cf1ce6c9b4e0a1633a9256de0efefaf9f8d26924b1f3c8620cffb9db78e7d3076b
+  languageName: node
+  linkType: hard
+
 "eventemitter3@npm:^5.0.1":
   version: 5.0.1
   resolution: "eventemitter3@npm:5.0.1"
@@ -8211,7 +8311,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"events@npm:^3.2.0":
+"events@npm:^3.2.0, events@npm:^3.3.0":
   version: 3.3.0
   resolution: "events@npm:3.3.0"
   checksum: 10c0/d6b6f2adbccbcda74ddbab52ed07db727ef52e31a61ed26db9feb7dc62af7fc8e060defa65e5f8af9449b86b52cc1a1f6a79f2eafcf4e62add2b7a1fa4a432f6
@@ -8449,6 +8549,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-decode-uri-component@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "fast-decode-uri-component@npm:1.0.1"
+  checksum: 10c0/039d50c2e99d64f999c3f2126c23fbf75a04a4117e218a149ca0b1d2aeb8c834b7b19d643b9d35d4eabce357189a6a94085f78cf48869e6e26cc59b036284bc3
+  languageName: node
+  linkType: hard
+
 "fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
@@ -8483,10 +8590,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-json-stringify@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "fast-json-stringify@npm:6.0.0"
+  dependencies:
+    "@fastify/merge-json-schemas": "npm:^0.1.1"
+    ajv: "npm:^8.12.0"
+    ajv-formats: "npm:^3.0.1"
+    fast-deep-equal: "npm:^3.1.3"
+    fast-uri: "npm:^2.3.0"
+    json-schema-ref-resolver: "npm:^1.0.1"
+    rfdc: "npm:^1.2.0"
+  checksum: 10c0/590bbb284df45972822773ebc41c8592c412cc8c2d123d43a41579c9972ff8004d1aea7d0c7cffaebf246ee28be964d605ad9d52bb96c26d8dc5fa4e225c1998
+  languageName: node
+  linkType: hard
+
 "fast-levenshtein@npm:^2.0.6":
   version: 2.0.6
   resolution: "fast-levenshtein@npm:2.0.6"
   checksum: 10c0/111972b37338bcb88f7d9e2c5907862c280ebf4234433b95bc611e518d192ccb2d38119c4ac86e26b668d75f7f3894f4ff5c4982899afced7ca78633b08287c4
+  languageName: node
+  linkType: hard
+
+"fast-querystring@npm:^1.0.0":
+  version: 1.1.2
+  resolution: "fast-querystring@npm:1.1.2"
+  dependencies:
+    fast-decode-uri-component: "npm:^1.0.1"
+  checksum: 10c0/e8223273a9b199722f760f5a047a77ad049a14bd444b821502cb8218f5925e3a5fffb56b64389bca73ab2ac6f1aa7aebbe4e203e5f6e53ff5978de97c0fde4e3
+  languageName: node
+  linkType: hard
+
+"fast-redact@npm:^3.1.1":
+  version: 3.5.0
+  resolution: "fast-redact@npm:3.5.0"
+  checksum: 10c0/7e2ce4aad6e7535e0775bf12bd3e4f2e53d8051d8b630e0fa9e67f68cb0b0e6070d2f7a94b1d0522ef07e32f7c7cda5755e2b677a6538f1e9070ca053c42343a
   languageName: node
   linkType: hard
 
@@ -8497,6 +8635,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-uri@npm:^2.3.0":
+  version: 2.4.0
+  resolution: "fast-uri@npm:2.4.0"
+  checksum: 10c0/300453cfe2f7d5ec16be0f2c8dc5b280edbaca59440b2deb4ab56ac0f584637179e9ee7539d0b70ef0fce9608245ebfa75307c84fa4829b1065c3b7ef7dcf706
+  languageName: node
+  linkType: hard
+
+"fast-uri@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "fast-uri@npm:3.0.2"
+  checksum: 10c0/8cdd3da7b4022a037d348d587d55caff74b7e4f862bbdd2cc35c1e6e3f97d0aedb567894d44c57ee8798d3192cceb97dcf41dbdabfa07dd2842a0474a6c6eeef
+  languageName: node
+  linkType: hard
+
 "fast-uri@npm:^3.0.1":
   version: 3.0.1
   resolution: "fast-uri@npm:3.0.1"
@@ -8504,7 +8656,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fastq@npm:^1.6.0":
+"fastify@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "fastify@npm:5.0.0"
+  dependencies:
+    "@fastify/ajv-compiler": "npm:^4.0.0"
+    "@fastify/error": "npm:^4.0.0"
+    "@fastify/fast-json-stringify-compiler": "npm:^5.0.0"
+    abstract-logging: "npm:^2.0.1"
+    avvio: "npm:^9.0.0"
+    fast-json-stringify: "npm:^6.0.0"
+    find-my-way: "npm:^9.0.0"
+    light-my-request: "npm:^6.0.0"
+    pino: "npm:^9.0.0"
+    process-warning: "npm:^4.0.0"
+    proxy-addr: "npm:^2.0.7"
+    rfdc: "npm:^1.3.1"
+    secure-json-parse: "npm:^2.7.0"
+    semver: "npm:^7.6.0"
+    toad-cache: "npm:^3.7.0"
+  checksum: 10c0/566e0948f7fd40c74e847d8bdcd320abd9d086e82020fd1fdd6a95f5b8bdf8d8c793873f6232893361afebe6e62d1687218860097cc3c502c403b15f93f3ce07
+  languageName: node
+  linkType: hard
+
+"fastq@npm:^1.17.1, fastq@npm:^1.6.0":
   version: 1.17.1
   resolution: "fastq@npm:1.17.1"
   dependencies:
@@ -8609,6 +8784,17 @@ __metadata:
     statuses: "npm:2.0.1"
     unpipe: "npm:~1.0.0"
   checksum: 10c0/64b7e5ff2ad1fcb14931cd012651631b721ce657da24aedb5650ddde9378bf8e95daa451da43398123f5de161a81e79ff5affe4f9f2a6d2df4a813d6d3e254b7
+  languageName: node
+  linkType: hard
+
+"find-my-way@npm:^9.0.0":
+  version: 9.1.0
+  resolution: "find-my-way@npm:9.1.0"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.3"
+    fast-querystring: "npm:^1.0.0"
+    safe-regex2: "npm:^4.0.0"
+  checksum: 10c0/ddde633673b512940f8d183c8684f1441d623464364f931af979a71baa0cb5b774ed574a80eaddba40fc605c7d35bc1c74c9469732eaf381a1c4a3e59611686f
   languageName: node
   linkType: hard
 
@@ -11351,6 +11537,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-schema-ref-resolver@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "json-schema-ref-resolver@npm:1.0.1"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.3"
+  checksum: 10c0/aa89d88108c0109ae35b913c89c132fb50c00f3b99fc8a8309b524b9e3a6a77414f19a6a35a1253871462984cbabc74279ebbd9bf103c6629fb7b37c9fb59bcf
+  languageName: node
+  linkType: hard
+
 "json-schema-traverse@npm:^0.4.1":
   version: 0.4.1
   resolution: "json-schema-traverse@npm:0.4.1"
@@ -11546,6 +11741,17 @@ __metadata:
     prelude-ls: "npm:^1.2.1"
     type-check: "npm:~0.4.0"
   checksum: 10c0/effb03cad7c89dfa5bd4f6989364bfc79994c2042ec5966cb9b95990e2edee5cd8969ddf42616a0373ac49fac1403437deaf6e9050fbbaa3546093a59b9ac94e
+  languageName: node
+  linkType: hard
+
+"light-my-request@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "light-my-request@npm:6.0.0"
+  dependencies:
+    cookie: "npm:^0.6.0"
+    process-warning: "npm:^4.0.0"
+    set-cookie-parser: "npm:^2.6.0"
+  checksum: 10c0/521fde58b0e52d05cc38b23a7ef5b9b7ce35b9a943a4e5a27eb219de2ac08ff566bfaa194b8db3bf99cf0800adc5fe5ed9c0c604c18fce8a0d4554e2237ee89b
   languageName: node
   linkType: hard
 
@@ -13293,6 +13499,7 @@ __metadata:
     "@types/jest": "npm:^29.5.12"
     "@types/lodash": "npm:^4.17.5"
     "@types/node": "npm:^22.5.0"
+    fastify: "npm:^5.0.0"
     func-loc: "npm:^0.1.16"
     jest: "npm:^29.7.0"
     lodash: "npm:^4.17.21"
@@ -13885,6 +14092,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"on-exit-leak-free@npm:^2.1.0":
+  version: 2.1.2
+  resolution: "on-exit-leak-free@npm:2.1.2"
+  checksum: 10c0/faea2e1c9d696ecee919026c32be8d6a633a7ac1240b3b87e944a380e8a11dc9c95c4a1f8fb0568de7ab8db3823e790f12bda45296b1d111e341aad3922a0570
+  languageName: node
+  linkType: hard
+
 "on-finished@npm:2.4.1":
   version: 2.4.1
   resolution: "on-finished@npm:2.4.1"
@@ -14438,6 +14652,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pino-abstract-transport@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "pino-abstract-transport@npm:1.2.0"
+  dependencies:
+    readable-stream: "npm:^4.0.0"
+    split2: "npm:^4.0.0"
+  checksum: 10c0/b4ab59529b7a91f488440147fc58ee0827a6c1c5ca3627292339354b1381072c1a6bfa9b46d03ad27872589e8477ecf74da12cf286e1e6b665ac64a3b806bf07
+  languageName: node
+  linkType: hard
+
+"pino-std-serializers@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "pino-std-serializers@npm:7.0.0"
+  checksum: 10c0/73e694d542e8de94445a03a98396cf383306de41fd75ecc07085d57ed7a57896198508a0dec6eefad8d701044af21eb27253ccc352586a03cf0d4a0bd25b4133
+  languageName: node
+  linkType: hard
+
+"pino@npm:^9.0.0":
+  version: 9.4.0
+  resolution: "pino@npm:9.4.0"
+  dependencies:
+    atomic-sleep: "npm:^1.0.0"
+    fast-redact: "npm:^3.1.1"
+    on-exit-leak-free: "npm:^2.1.0"
+    pino-abstract-transport: "npm:^1.2.0"
+    pino-std-serializers: "npm:^7.0.0"
+    process-warning: "npm:^4.0.0"
+    quick-format-unescaped: "npm:^4.0.3"
+    real-require: "npm:^0.2.0"
+    safe-stable-stringify: "npm:^2.3.1"
+    sonic-boom: "npm:^4.0.1"
+    thread-stream: "npm:^3.0.0"
+  bin:
+    pino: bin.js
+  checksum: 10c0/12a3d74968964d92b18ca7d6095a3c5b86478dc22264a37486d64e102085ed08820fcbe75e640acc3542fdf2937a34e5050b624f98e6ac62dd10f5e1328058a2
+  languageName: node
+  linkType: hard
+
 "pinst@npm:^3.0.0":
   version: 3.0.0
   resolution: "pinst@npm:3.0.0"
@@ -14653,7 +14905,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"process@npm:^0.11.1":
+"process-warning@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "process-warning@npm:4.0.0"
+  checksum: 10c0/5312a72b69d37a1b82ad03f3dfa0090dab3804a8fd995d06c28e3c002852bd82f5584217d9f4a3f197892bb2afc22d57e2c662c7e906b5abb48c0380c7b0880d
+  languageName: node
+  linkType: hard
+
+"process@npm:^0.11.1, process@npm:^0.11.10":
   version: 0.11.10
   resolution: "process@npm:0.11.10"
   checksum: 10c0/40c3ce4b7e6d4b8c3355479df77aeed46f81b279818ccdc500124e6a5ab882c0cc81ff7ea16384873a95a74c4570b01b120f287abbdd4c877931460eca6084b3
@@ -14726,7 +14985,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxy-addr@npm:~2.0.7":
+"proxy-addr@npm:^2.0.7, proxy-addr@npm:~2.0.7":
   version: 2.0.7
   resolution: "proxy-addr@npm:2.0.7"
   dependencies:
@@ -14828,6 +15087,13 @@ __metadata:
   version: 1.2.3
   resolution: "queue-microtask@npm:1.2.3"
   checksum: 10c0/900a93d3cdae3acd7d16f642c29a642aea32c2026446151f0778c62ac089d4b8e6c986811076e1ae180a694cedf077d453a11b58ff0a865629a4f82ab558e102
+  languageName: node
+  linkType: hard
+
+"quick-format-unescaped@npm:^4.0.3":
+  version: 4.0.4
+  resolution: "quick-format-unescaped@npm:4.0.4"
+  checksum: 10c0/fe5acc6f775b172ca5b4373df26f7e4fd347975578199e7d74b2ae4077f0af05baa27d231de1e80e8f72d88275ccc6028568a7a8c9ee5e7368ace0e18eff93a4
   languageName: node
   linkType: hard
 
@@ -14994,6 +15260,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"readable-stream@npm:^4.0.0":
+  version: 4.5.2
+  resolution: "readable-stream@npm:4.5.2"
+  dependencies:
+    abort-controller: "npm:^3.0.0"
+    buffer: "npm:^6.0.3"
+    events: "npm:^3.3.0"
+    process: "npm:^0.11.10"
+    string_decoder: "npm:^1.3.0"
+  checksum: 10c0/a2c80e0e53aabd91d7df0330929e32d0a73219f9477dbbb18472f6fdd6a11a699fc5d172a1beff98d50eae4f1496c950ffa85b7cc2c4c196963f289a5f39275d
+  languageName: node
+  linkType: hard
+
 "readable-web-to-node-stream@npm:^3.0.2":
   version: 3.0.2
   resolution: "readable-web-to-node-stream@npm:3.0.2"
@@ -15016,6 +15295,13 @@ __metadata:
   version: 1.5.0
   resolution: "reading-time@npm:1.5.0"
   checksum: 10c0/0f730852fd4fb99e5f78c5b0cf36ab8c3fa15db96f87d9563843f6fd07a47864273ade539ebb184b785b728cde81a70283aa2d9b80cba5ca03b81868be03cabc
+  languageName: node
+  linkType: hard
+
+"real-require@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "real-require@npm:0.2.0"
+  checksum: 10c0/23eea5623642f0477412ef8b91acd3969015a1501ed34992ada0e3af521d3c865bb2fe4cdbfec5fe4b505f6d1ef6a03e5c3652520837a8c3b53decff7e74b6a0
   languageName: node
   linkType: hard
 
@@ -15471,6 +15757,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ret@npm:~0.5.0":
+  version: 0.5.0
+  resolution: "ret@npm:0.5.0"
+  checksum: 10c0/220868b194f87bf1998e32e409086eec6b39e860c052bf267f8ad4d0131706a9773d45fd3f91acfb1a7c928fce002b694ab86fdba90bc8d4b8df68fa8645c5cc
+  languageName: node
+  linkType: hard
+
 "retry@npm:0.13.1":
   version: 0.13.1
   resolution: "retry@npm:0.13.1"
@@ -15492,7 +15785,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rfdc@npm:^1.4.1":
+"rfdc@npm:^1.2.0, rfdc@npm:^1.3.1, rfdc@npm:^1.4.1":
   version: 1.4.1
   resolution: "rfdc@npm:1.4.1"
   checksum: 10c0/4614e4292356cafade0b6031527eea9bc90f2372a22c012313be1dcc69a3b90c7338158b414539be863fa95bfcb2ddcd0587be696841af4e6679d85e62c060c7
@@ -15621,6 +15914,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"safe-regex2@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "safe-regex2@npm:4.0.0"
+  dependencies:
+    ret: "npm:~0.5.0"
+  checksum: 10c0/faebf910036228868e83b4a33a84405b04e8e89f01283efe847e17e96b6b4658cc65c6560cef11de3bd5aef3b28b58dffac48744df67ca2ae46e073f668cb71d
+  languageName: node
+  linkType: hard
+
+"safe-stable-stringify@npm:^2.3.1":
+  version: 2.5.0
+  resolution: "safe-stable-stringify@npm:2.5.0"
+  checksum: 10c0/baea14971858cadd65df23894a40588ed791769db21bafb7fd7608397dbdce9c5aac60748abae9995e0fc37e15f2061980501e012cd48859740796bea2987f49
+  languageName: node
+  linkType: hard
+
 "safer-buffer@npm:>= 2.1.2 < 3, safer-buffer@npm:>= 2.1.2 < 3.0.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
@@ -15664,6 +15973,13 @@ __metadata:
     extend-shallow: "npm:^2.0.1"
     kind-of: "npm:^6.0.0"
   checksum: 10c0/8007f91780adc5aaa781a848eaae50b0f680bbf4043b90cf8a96778195b8fab690c87fe7a989e02394ce69890e330811ec8dab22397d384673ce59f7d750641d
+  languageName: node
+  linkType: hard
+
+"secure-json-parse@npm:^2.7.0":
+  version: 2.7.0
+  resolution: "secure-json-parse@npm:2.7.0"
+  checksum: 10c0/f57eb6a44a38a3eeaf3548228585d769d788f59007454214fab9ed7f01fbf2e0f1929111da6db28cf0bcc1a2e89db5219a59e83eeaec3a54e413a0197ce879e4
   languageName: node
   linkType: hard
 
@@ -15767,6 +16083,13 @@ __metadata:
   version: 0.0.1
   resolution: "server-only@npm:0.0.1"
   checksum: 10c0/4704f0ef85da0be981af6d4ed8e739d39bcfd265b9c246a684060acda5642d0fdc6daffc2308e71e2682c5f508090978802eae0a77623c9b90a49f9ae68048d6
+  languageName: node
+  linkType: hard
+
+"set-cookie-parser@npm:^2.6.0":
+  version: 2.7.0
+  resolution: "set-cookie-parser@npm:2.7.0"
+  checksum: 10c0/5ccb2d0389bda27631d57e44644319f0b77200e7c8bd1515824eb83dbd2d351864a29581f7e7f977a5aeb83c3ec9976e69b706a80ac654152fd26353011ffef4
   languageName: node
   linkType: hard
 
@@ -15962,6 +16285,15 @@ __metadata:
     ip-address: "npm:^9.0.5"
     smart-buffer: "npm:^4.2.0"
   checksum: 10c0/d54a52bf9325165770b674a67241143a3d8b4e4c8884560c4e0e078aace2a728dffc7f70150660f51b85797c4e1a3b82f9b7aa25e0a0ceae1a243365da5c51a7
+  languageName: node
+  linkType: hard
+
+"sonic-boom@npm:^4.0.1":
+  version: 4.1.0
+  resolution: "sonic-boom@npm:4.1.0"
+  dependencies:
+    atomic-sleep: "npm:^1.0.0"
+  checksum: 10c0/4c9e082db296fbfb02e22a1a9b8de8b82f5965697dda3fe7feadc4759bf25d1de0094e3c35f16e015bfdc00fad7b8cf15bef5b0144501a2a5c5b86efb5684096
   languageName: node
   linkType: hard
 
@@ -16267,7 +16599,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string_decoder@npm:^1.1.1":
+"string_decoder@npm:^1.1.1, string_decoder@npm:^1.3.0":
   version: 1.3.0
   resolution: "string_decoder@npm:1.3.0"
   dependencies:
@@ -16687,6 +17019,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"thread-stream@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "thread-stream@npm:3.1.0"
+  dependencies:
+    real-require: "npm:^0.2.0"
+  checksum: 10c0/c36118379940b77a6ef3e6f4d5dd31e97b8210c3f7b9a54eb8fe6358ab173f6d0acfaf69b9c3db024b948c0c5fd2a7df93e2e49151af02076b35ada3205ec9a6
+  languageName: node
+  linkType: hard
+
 "through@npm:>=2.2.7 <3, through@npm:^2.3.6":
   version: 2.3.8
   resolution: "through@npm:2.3.8"
@@ -16744,6 +17085,13 @@ __metadata:
   dependencies:
     is-number: "npm:^7.0.0"
   checksum: 10c0/487988b0a19c654ff3e1961b87f471702e708fa8a8dd02a298ef16da7206692e8552a0250e8b3e8759270f62e9d8314616f6da274734d3b558b1fc7b7724e892
+  languageName: node
+  linkType: hard
+
+"toad-cache@npm:^3.7.0":
+  version: 3.7.0
+  resolution: "toad-cache@npm:3.7.0"
+  checksum: 10c0/7dae2782ee20b22c9798bb8b71dec7ec6a0091021d2ea9dd6e8afccab6b65b358fdba49a02209fac574499702e2c000660721516c87c2538d1b2c0ba03e8c0c3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1901,6 +1901,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@fastify/ajv-compiler@npm:^3.5.0":
+  version: 3.6.0
+  resolution: "@fastify/ajv-compiler@npm:3.6.0"
+  dependencies:
+    ajv: "npm:^8.11.0"
+    ajv-formats: "npm:^2.1.1"
+    fast-uri: "npm:^2.0.0"
+  checksum: 10c0/f0be2ca1f75833492829c52c5f5ef0ec118bdd010614e002a6366952c27297c0f6a7dafb5917a0f9c4aaa84aa32a39e520c6d837fa251748717d58590cfc8177
+  languageName: node
+  linkType: hard
+
 "@fastify/ajv-compiler@npm:^4.0.0":
   version: 4.0.1
   resolution: "@fastify/ajv-compiler@npm:4.0.1"
@@ -1912,10 +1923,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@fastify/cors@npm:9.0.1":
+  version: 9.0.1
+  resolution: "@fastify/cors@npm:9.0.1"
+  dependencies:
+    fastify-plugin: "npm:^4.0.0"
+    mnemonist: "npm:0.39.6"
+  checksum: 10c0/4db9d3d02edbca741c8ed053819bf3b235ecd70e07c640ed91ba0fc1ee2dc8abedbbffeb79ae1a38ccbf59832e414cad90a554ee44227d0811d5a2d062940611
+  languageName: node
+  linkType: hard
+
+"@fastify/error@npm:^3.2.0, @fastify/error@npm:^3.3.0, @fastify/error@npm:^3.4.0":
+  version: 3.4.1
+  resolution: "@fastify/error@npm:3.4.1"
+  checksum: 10c0/1f1a0faa8c86639afb6f4bd47a9cdc1f0f20ce0d6944340fbdec8218aaba91dc9cae9ed78e24e61bceb782a867efda2b9a6320091f00dcbb896d9c8a9bdf5f96
+  languageName: node
+  linkType: hard
+
 "@fastify/error@npm:^4.0.0":
   version: 4.0.0
   resolution: "@fastify/error@npm:4.0.0"
   checksum: 10c0/074b8a6c350c29a8fc8314298d9457fe0c1ba6e7f160e9ae6ba0e18853f1ec7427d768f966700cbf67a4694f3a9a593c6a23e42ce3ed62e40fecdf8026040d9a
+  languageName: node
+  linkType: hard
+
+"@fastify/fast-json-stringify-compiler@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "@fastify/fast-json-stringify-compiler@npm:4.3.0"
+  dependencies:
+    fast-json-stringify: "npm:^5.7.0"
+  checksum: 10c0/513ef296f5ed682f7a460cfa6c5fb917a32fc540111b873c9937f944558e021492b18f30f9fd8dd20db252381a4428adbcc9f03a077f16c86d02f081eb490c7b
   languageName: node
   linkType: hard
 
@@ -1928,12 +1965,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fastify/merge-json-schemas@npm:^0.1.1":
+"@fastify/formbody@npm:7.4.0":
+  version: 7.4.0
+  resolution: "@fastify/formbody@npm:7.4.0"
+  dependencies:
+    fast-querystring: "npm:^1.0.0"
+    fastify-plugin: "npm:^4.0.0"
+  checksum: 10c0/128aa7c2a4e975242bf40f18519cb7a26e768478e56754423ba99cbc05946fcb98f53d87c65eafab7ef2ed68e4b95f4d7e1d14e31355e346d9c717dd689e1fa8
+  languageName: node
+  linkType: hard
+
+"@fastify/merge-json-schemas@npm:^0.1.0, @fastify/merge-json-schemas@npm:^0.1.1":
   version: 0.1.1
   resolution: "@fastify/merge-json-schemas@npm:0.1.1"
   dependencies:
     fast-deep-equal: "npm:^3.1.3"
   checksum: 10c0/7979ce12724f7b98aea06f0bb9afb20dd869f0ff6fc697517135cbb54e0a36b062cbb38ec176fe43d1fc455576839240df8f33533939ace2d64a6218a6e6b9c1
+  languageName: node
+  linkType: hard
+
+"@fastify/middie@npm:8.3.3":
+  version: 8.3.3
+  resolution: "@fastify/middie@npm:8.3.3"
+  dependencies:
+    "@fastify/error": "npm:^3.2.0"
+    fastify-plugin: "npm:^4.0.0"
+    path-to-regexp: "npm:^6.3.0"
+    reusify: "npm:^1.0.4"
+  checksum: 10c0/802a1a51d25d2651fcdd223f058530cad8c8b55a9adb764bd47e55e4656d1c4b3ce71a58fe40c8307ddef56750ce0ba93b9df14ead5d01e2a6590b677ec393ab
   languageName: node
   linkType: hard
 
@@ -2674,6 +2733,31 @@ __metadata:
     "@nestjs/common": ^10.0.0
     "@nestjs/core": ^10.0.0
   checksum: 10c0/7ca0b011eff3e3a3efbc0e0df9e874943f5acced3966350202d01e0e3bb65ea37de7cfb6d60bd3150f679a733ee33273fcbdc65146d18964b7e58116ed0d873a
+  languageName: node
+  linkType: hard
+
+"@nestjs/platform-fastify@npm:^10.4.4":
+  version: 10.4.4
+  resolution: "@nestjs/platform-fastify@npm:10.4.4"
+  dependencies:
+    "@fastify/cors": "npm:9.0.1"
+    "@fastify/formbody": "npm:7.4.0"
+    "@fastify/middie": "npm:8.3.3"
+    fastify: "npm:4.28.1"
+    light-my-request: "npm:6.0.0"
+    path-to-regexp: "npm:3.3.0"
+    tslib: "npm:2.7.0"
+  peerDependencies:
+    "@fastify/static": ^6.0.0 || ^7.0.0
+    "@fastify/view": ^7.0.0 || ^8.0.0
+    "@nestjs/common": ^10.0.0
+    "@nestjs/core": ^10.0.0
+  peerDependenciesMeta:
+    "@fastify/static":
+      optional: true
+    "@fastify/view":
+      optional: true
+  checksum: 10c0/fed6c8b8306e7a373dbd67befbc49fe61a3511f12a62a86bec537053d8fb065aa16d3147b544b176b6c4b8591fad8cbd8ac2208df78628b3d6fdf45fcaa66c10
   languageName: node
   linkType: hard
 
@@ -4737,7 +4821,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv-formats@npm:2.1.1":
+"ajv-formats@npm:2.1.1, ajv-formats@npm:^2.1.1":
   version: 2.1.1
   resolution: "ajv-formats@npm:2.1.1"
   dependencies:
@@ -4798,7 +4882,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^8.0.0, ajv@npm:^8.11.0, ajv@npm:^8.12.0":
+"ajv@npm:^8.0.0, ajv@npm:^8.10.0, ajv@npm:^8.11.0, ajv@npm:^8.12.0":
   version: 8.17.1
   resolution: "ajv@npm:8.17.1"
   dependencies:
@@ -5211,6 +5295,16 @@ __metadata:
   dependencies:
     possible-typed-array-names: "npm:^1.0.0"
   checksum: 10c0/d07226ef4f87daa01bd0fe80f8f310982e345f372926da2e5296aecc25c41cab440916bbaa4c5e1034b453af3392f67df5961124e4b586df1e99793a1374bdb2
+  languageName: node
+  linkType: hard
+
+"avvio@npm:^8.3.0":
+  version: 8.4.0
+  resolution: "avvio@npm:8.4.0"
+  dependencies:
+    "@fastify/error": "npm:^3.3.0"
+    fastq: "npm:^1.17.1"
+  checksum: 10c0/bea7f28e38b57755786852226f380ea087d572f8bbcfe14b59d1239551ef89cecc40229a6ac85e17af44c81a481d03280576586385e93d76bb9f2c5bc75c6067
   languageName: node
   linkType: hard
 
@@ -8347,6 +8441,35 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"example-nestjs-fastify@workspace:examples/nestjs-fastify":
+  version: 0.0.0-use.local
+  resolution: "example-nestjs-fastify@workspace:examples/nestjs-fastify"
+  dependencies:
+    "@nestjs/cli": "npm:10.4.4"
+    "@nestjs/common": "npm:10.4.1"
+    "@nestjs/config": "npm:^3.0.0"
+    "@nestjs/core": "npm:10.4.1"
+    "@nestjs/platform-fastify": "npm:^10.4.4"
+    "@nestjs/schematics": "npm:^10.1.2"
+    "@swc/cli": "npm:^0.4.0"
+    "@swc/core": "npm:^1.7.18"
+    "@trpc/server": "npm:^10.33.0"
+    "@types/node": "npm:^22.5.0"
+    chokidar: "npm:^3.6.0"
+    fastify: "npm:^5.0.0"
+    nestjs-trpc: "workspace:*"
+    reflect-metadata: "npm:^0.1.13"
+    rxjs: "npm:^7.2.0"
+    trpc-panel: "npm:^1.3.4"
+    ts-morph: "npm:^23.0.0"
+    ts-node: "npm:^10.9.1"
+    tsconfig-paths: "npm:^4.2.0"
+    tslib: "npm:^2.5.0"
+    typescript: "npm:^5.0.3"
+    zod: "npm:^3.21.4"
+  languageName: unknown
+  linkType: soft
+
 "execa@npm:8.0.1, execa@npm:^8.0.1, execa@npm:~8.0.1":
   version: 8.0.1
   resolution: "execa@npm:8.0.1"
@@ -8549,6 +8672,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-content-type-parse@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "fast-content-type-parse@npm:1.1.0"
+  checksum: 10c0/882bf990fa5d64be1825ce183818db43900ece0d7ef184cb9409bae8ed1001acbe536a657b1496382cb3e308e71ab39cc399bbdae70cba1745eecaeca4e55384
+  languageName: node
+  linkType: hard
+
 "fast-decode-uri-component@npm:^1.0.1":
   version: 1.0.1
   resolution: "fast-decode-uri-component@npm:1.0.1"
@@ -8587,6 +8717,21 @@ __metadata:
   version: 2.1.0
   resolution: "fast-json-stable-stringify@npm:2.1.0"
   checksum: 10c0/7f081eb0b8a64e0057b3bb03f974b3ef00135fbf36c1c710895cd9300f13c94ba809bb3a81cf4e1b03f6e5285610a61abbd7602d0652de423144dfee5a389c9b
+  languageName: node
+  linkType: hard
+
+"fast-json-stringify@npm:^5.7.0, fast-json-stringify@npm:^5.8.0":
+  version: 5.16.1
+  resolution: "fast-json-stringify@npm:5.16.1"
+  dependencies:
+    "@fastify/merge-json-schemas": "npm:^0.1.0"
+    ajv: "npm:^8.10.0"
+    ajv-formats: "npm:^3.0.1"
+    fast-deep-equal: "npm:^3.1.3"
+    fast-uri: "npm:^2.1.0"
+    json-schema-ref-resolver: "npm:^1.0.1"
+    rfdc: "npm:^1.2.0"
+  checksum: 10c0/bbf955d9912fb827dff0e097fdbff3c11aec540ea8019a19593a16224cac70d49d0cebd98e412843fc72259184f73a78a45e63040d3c44349f4735a492f2f1a4
   languageName: node
   linkType: hard
 
@@ -8635,7 +8780,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^2.3.0":
+"fast-uri@npm:^2.0.0, fast-uri@npm:^2.1.0, fast-uri@npm:^2.3.0":
   version: 2.4.0
   resolution: "fast-uri@npm:2.4.0"
   checksum: 10c0/300453cfe2f7d5ec16be0f2c8dc5b280edbaca59440b2deb4ab56ac0f584637179e9ee7539d0b70ef0fce9608245ebfa75307c84fa4829b1065c3b7ef7dcf706
@@ -8653,6 +8798,37 @@ __metadata:
   version: 3.0.1
   resolution: "fast-uri@npm:3.0.1"
   checksum: 10c0/3cd46d6006083b14ca61ffe9a05b8eef75ef87e9574b6f68f2e17ecf4daa7aaadeff44e3f0f7a0ef4e0f7e7c20fc07beec49ff14dc72d0b500f00386592f2d10
+  languageName: node
+  linkType: hard
+
+"fastify-plugin@npm:^4.0.0":
+  version: 4.5.1
+  resolution: "fastify-plugin@npm:4.5.1"
+  checksum: 10c0/f58f79cd9d3c88fd7f79a3270276c6339fc57bbe72ef14d20b73779193c404e317ac18e8eae2c5071b3909ebee45d7eb6871da4e65464ac64ed0d9746b4e9b9f
+  languageName: node
+  linkType: hard
+
+"fastify@npm:4.28.1":
+  version: 4.28.1
+  resolution: "fastify@npm:4.28.1"
+  dependencies:
+    "@fastify/ajv-compiler": "npm:^3.5.0"
+    "@fastify/error": "npm:^3.4.0"
+    "@fastify/fast-json-stringify-compiler": "npm:^4.3.0"
+    abstract-logging: "npm:^2.0.1"
+    avvio: "npm:^8.3.0"
+    fast-content-type-parse: "npm:^1.1.0"
+    fast-json-stringify: "npm:^5.8.0"
+    find-my-way: "npm:^8.0.0"
+    light-my-request: "npm:^5.11.0"
+    pino: "npm:^9.0.0"
+    process-warning: "npm:^3.0.0"
+    proxy-addr: "npm:^2.0.7"
+    rfdc: "npm:^1.3.0"
+    secure-json-parse: "npm:^2.7.0"
+    semver: "npm:^7.5.4"
+    toad-cache: "npm:^3.3.0"
+  checksum: 10c0/9c212e9a72c42a27ebc9b0bc7fda8f94ff208250158093374942b0e156a3f55fa848c926921f99bdf7f38f6f8103ac28ecc72cc507f33893cd121ce4f3eda069
   languageName: node
   linkType: hard
 
@@ -8784,6 +8960,17 @@ __metadata:
     statuses: "npm:2.0.1"
     unpipe: "npm:~1.0.0"
   checksum: 10c0/64b7e5ff2ad1fcb14931cd012651631b721ce657da24aedb5650ddde9378bf8e95daa451da43398123f5de161a81e79ff5affe4f9f2a6d2df4a813d6d3e254b7
+  languageName: node
+  linkType: hard
+
+"find-my-way@npm:^8.0.0":
+  version: 8.2.2
+  resolution: "find-my-way@npm:8.2.2"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.3"
+    fast-querystring: "npm:^1.0.0"
+    safe-regex2: "npm:^3.1.0"
+  checksum: 10c0/ce462b2033e08a82fa79b837e4ef9e637d5f3e6763564631ad835b4e50b22e2123c0bf27c4fe6b02bc4006cd7949c0351d2b6b6f32248e839b10bdcbd3a3269f
   languageName: node
   linkType: hard
 
@@ -11744,7 +11931,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"light-my-request@npm:^6.0.0":
+"light-my-request@npm:6.0.0, light-my-request@npm:^6.0.0":
   version: 6.0.0
   resolution: "light-my-request@npm:6.0.0"
   dependencies:
@@ -11752,6 +11939,17 @@ __metadata:
     process-warning: "npm:^4.0.0"
     set-cookie-parser: "npm:^2.6.0"
   checksum: 10c0/521fde58b0e52d05cc38b23a7ef5b9b7ce35b9a943a4e5a27eb219de2ac08ff566bfaa194b8db3bf99cf0800adc5fe5ed9c0c604c18fce8a0d4554e2237ee89b
+  languageName: node
+  linkType: hard
+
+"light-my-request@npm:^5.11.0":
+  version: 5.13.0
+  resolution: "light-my-request@npm:5.13.0"
+  dependencies:
+    cookie: "npm:^0.6.0"
+    process-warning: "npm:^3.0.0"
+    set-cookie-parser: "npm:^2.4.1"
+  checksum: 10c0/460117f30e09c2eec3a62e6ba4264111a28b881fdd0ea79493ed889ebf69a56482d603f0685a0e2930b5ec53205d28c46f3cdf13d7888914852eb7c4dac83285
   languageName: node
   linkType: hard
 
@@ -13323,6 +13521,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mnemonist@npm:0.39.6":
+  version: 0.39.6
+  resolution: "mnemonist@npm:0.39.6"
+  dependencies:
+    obliterator: "npm:^2.0.1"
+  checksum: 10c0/a538945ea547976136ee6e16f224c0a50983143619941f6c4d2c82159e36eb6f8ee93d69d3a1267038fc5b16f88e2d43390023de10dfb145fa15c5e2befa1cdf
+  languageName: node
+  linkType: hard
+
 "mri@npm:^1.1.0":
   version: 1.2.0
   resolution: "mri@npm:1.2.0"
@@ -14092,6 +14299,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"obliterator@npm:^2.0.1":
+  version: 2.0.4
+  resolution: "obliterator@npm:2.0.4"
+  checksum: 10c0/ff2c10d4de7d62cd1d588b4d18dfc42f246c9e3a259f60d5716f7f88e5b3a3f79856b3207db96ec9a836a01d0958a21c15afa62a3f4e73a1e0b75f2c2f6bab40
+  languageName: node
+  linkType: hard
+
 "on-exit-leak-free@npm:^2.1.0":
   version: 2.1.2
   resolution: "on-exit-leak-free@npm:2.1.2"
@@ -14573,6 +14787,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-to-regexp@npm:3.3.0":
+  version: 3.3.0
+  resolution: "path-to-regexp@npm:3.3.0"
+  checksum: 10c0/ffa0ebe7088d38d435a8d08b0fe6e8c93ceb2a81a65d4dd1d9a538f52e09d5e3474ed5f553cb3b180d894b0caa10698a68737ab599fd1e56b4663d1a64c9f77b
+  languageName: node
+  linkType: hard
+
+"path-to-regexp@npm:^6.3.0":
+  version: 6.3.0
+  resolution: "path-to-regexp@npm:6.3.0"
+  checksum: 10c0/73b67f4638b41cde56254e6354e46ae3a2ebc08279583f6af3d96fe4664fc75788f74ed0d18ca44fa4a98491b69434f9eee73b97bb5314bd1b5adb700f5c18d6
+  languageName: node
+  linkType: hard
+
 "path-type@npm:^4.0.0":
   version: 4.0.0
   resolution: "path-type@npm:4.0.0"
@@ -14902,6 +15130,13 @@ __metadata:
   version: 2.0.1
   resolution: "process-nextick-args@npm:2.0.1"
   checksum: 10c0/bec089239487833d46b59d80327a1605e1c5287eaad770a291add7f45fda1bb5e28b38e0e061add0a1d0ee0984788ce74fa394d345eed1c420cacf392c554367
+  languageName: node
+  linkType: hard
+
+"process-warning@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "process-warning@npm:3.0.0"
+  checksum: 10c0/60f3c8ddee586f0706c1e6cb5aa9c86df05774b9330d792d7c8851cf0031afd759d665404d07037e0b4901b55c44a423f07bdc465c63de07d8d23196bb403622
   languageName: node
   linkType: hard
 
@@ -15757,6 +15992,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ret@npm:~0.4.0":
+  version: 0.4.3
+  resolution: "ret@npm:0.4.3"
+  checksum: 10c0/93e4e81cf393ebbafa1a26816e0b22ad0e2539c10e267d46ce8754c3f385b7aa839772ee1f83fdd2487b43d1081f29af41a19160e85456311f6f1778e14ba66b
+  languageName: node
+  linkType: hard
+
 "ret@npm:~0.5.0":
   version: 0.5.0
   resolution: "ret@npm:0.5.0"
@@ -15785,7 +16027,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rfdc@npm:^1.2.0, rfdc@npm:^1.3.1, rfdc@npm:^1.4.1":
+"rfdc@npm:^1.2.0, rfdc@npm:^1.3.0, rfdc@npm:^1.3.1, rfdc@npm:^1.4.1":
   version: 1.4.1
   resolution: "rfdc@npm:1.4.1"
   checksum: 10c0/4614e4292356cafade0b6031527eea9bc90f2372a22c012313be1dcc69a3b90c7338158b414539be863fa95bfcb2ddcd0587be696841af4e6679d85e62c060c7
@@ -15911,6 +16153,15 @@ __metadata:
     es-errors: "npm:^1.3.0"
     is-regex: "npm:^1.1.4"
   checksum: 10c0/900bf7c98dc58f08d8523b7012b468e4eb757afa624f198902c0643d7008ba777b0bdc35810ba0b758671ce887617295fb742b3f3968991b178ceca54cb07603
+  languageName: node
+  linkType: hard
+
+"safe-regex2@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "safe-regex2@npm:3.1.0"
+  dependencies:
+    ret: "npm:~0.4.0"
+  checksum: 10c0/5e5e7f9f116ddfd324b1fdc65ad4470937eebc8883d34669ce8c5afbda64f1954e5e4c2e754ef6281e5f6762e0b8c4e20fb9eec4d47355526f8cc1f6a9764624
   languageName: node
   linkType: hard
 
@@ -16086,7 +16337,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"set-cookie-parser@npm:^2.6.0":
+"set-cookie-parser@npm:^2.4.1, set-cookie-parser@npm:^2.6.0":
   version: 2.7.0
   resolution: "set-cookie-parser@npm:2.7.0"
   checksum: 10c0/5ccb2d0389bda27631d57e44644319f0b77200e7c8bd1515824eb83dbd2d351864a29581f7e7f977a5aeb83c3ec9976e69b706a80ac654152fd26353011ffef4
@@ -17088,7 +17339,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"toad-cache@npm:^3.7.0":
+"toad-cache@npm:^3.3.0, toad-cache@npm:^3.7.0":
   version: 3.7.0
   resolution: "toad-cache@npm:3.7.0"
   checksum: 10c0/7dae2782ee20b22c9798bb8b71dec7ec6a0091021d2ea9dd6e8afccab6b65b358fdba49a02209fac574499702e2c000660721516c87c2538d1b2c0ba03e8c0c3
@@ -17382,7 +17633,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.5.0, tslib@npm:^2.6.2":
+"tslib@npm:2.7.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.5.0, tslib@npm:^2.6.2":
   version: 2.7.0
   resolution: "tslib@npm:2.7.0"
   checksum: 10c0/469e1d5bf1af585742128827000711efa61010b699cb040ab1800bcd3ccdd37f63ec30642c9e07c4439c1db6e46345582614275daca3e0f4abae29b0083f04a6


### PR DESCRIPTION
This PR introduces support for the Fastify adapter, this includes:
- [x] Add support for the Fastify adapter.
- [x] Add an example for `nestjs-fastify`.
- [x] Update documentation and README.

I opted to obscure the `FastifyDriver` and the `ExpressDriver` because the actual difference in implementation is so small that it doesn't need to be passed through the options.

