### PR TITLE
refactor(decorators/middlewares): rename to `UseMiddlewares` and mark old one as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Here's a brief example demonstrating how to use the decorators available in **Ne
 ```typescript
 // users.router.ts
 import { Inject } from '@nestjs/common';
-import { Router, Query, Middlewares } from 'nestjs-trpc';
+import { Router, Query, UseMiddlewares } from 'nestjs-trpc';
 import { UserService } from './user.service';
 import { ProtectedMiddleware } from './protected.middleware';
 import { TRPCError } from '@trpc/server';
@@ -83,7 +83,7 @@ class UserRouter {
     @Inject(UserService) private readonly userService: UserService
   ) {}
 
-  @Middlewares(ProtectedMiddleware)
+  @UseMiddlewares(ProtectedMiddleware)
   @Query({ output: z.array(userSchema) })
   async getUsers() {
     try {

--- a/docs/pages/docs/client.mdx
+++ b/docs/pages/docs/client.mdx
@@ -23,7 +23,7 @@ Here is and example for a router, and the generated output:
   <Tabs.Tab>
     ```typescript filename="user.router.ts" copy
     import { Inject } from '@nestjs/common';
-    import { Router, Query, Middlewares, Input } from 'nestjs-trpc';
+    import { Router, Query, UseMiddlewares, Input } from 'nestjs-trpc';
     import { UserService } from './user.service';
     import { ProtectedMiddleware } from './protected.middleware';
     import { z } from 'zod';
@@ -38,7 +38,7 @@ Here is and example for a router, and the generated output:
             input: z.object({ userId: z.string() }),
             output: userSchema,
         })
-        @Middlewares(ProtectedMiddleware)
+        @UseMiddlewares(ProtectedMiddleware)
         async getUserById(@Input('userId') userId: string): Promise<User> {
             const user = await this.userService.getUser(userId);
 

--- a/docs/pages/docs/middlewares.mdx
+++ b/docs/pages/docs/middlewares.mdx
@@ -9,18 +9,18 @@ import TrpcIcon from '../../public/icons/trpc.svg';
 # Middlewares
 
 With this adapter you can create procedure middlewares, 
-These middlewares can be added to a router class, either globally for all procedures in that router or individually to specific procedures using the `@Middlewares(){:tsx}` decorator.
+These middlewares can be added to a router class, either globally for all procedures in that router or individually to specific procedures using the `@UseMiddlewares(){:tsx}` decorator.
 
-The `@Middlewares(){:tsx}` decorator accepts multiple middlewares, executing them in the provided order. For instance:
+The `@UseMiddlewares(){:tsx}` decorator accepts multiple middlewares, executing them in the provided order. For instance:
 ```ts
-@Middlewares(LoggingMiddleware, AuthMiddleware)
+@UseMiddlewares(LoggingMiddleware, AuthMiddleware)
 ```
 In this example, `LoggingMiddleware` runs first, followed by `AuthMiddleware`.  <br/>
-If both the router and the procedure have middlewares defined via `@Middlewares(){:tsx}`, the router-level middlewares will execute first, followed by the procedure-level middlewares, provided there are no duplicates.<br/>
+If both the router and the procedure have middlewares defined via `@UseMiddlewares(){:tsx}`, the router-level middlewares will execute first, followed by the procedure-level middlewares, provided there are no duplicates.<br/>
 This middleware approach in tRPC is similar to the `Guards` and `Middlewares` concept found in NestJS.
 
 <Callout>
-  If you are not sure about the basic concepts of NestJS or tRPC middlewares, you can dive into those concepts in their official documentation.
+  If you are not sure about the basic **concepts** of NestJS or tRPC middlewares, you can dive into those concepts in their official documentation.
 </Callout>
 <div className={"w-full router-cards"}>
   <Cards>
@@ -90,12 +90,12 @@ Similar to NestJS providers, we need to register the middleware with Nest so tha
 We do this by editing our module file and adding the middleware to the `providers` array of the `@Module(){:tsx}` decorator.
 
 ### Applying middleware
-To use the middleware in your procedure instead of the default `publicProcedure`, pass the class to the `@Middlewares(){:tsx}` method decorator.
+To use the middleware in your procedure instead of the default `publicProcedure`, pass the class to the `@UseMiddlewares(){:tsx}` method decorator.
 ```typescript {17} filename="dogs.router.ts" copy showLineNumbers
 import { DatabaseService } from "./database.service.ts";
 import { LoggedMiddleware } from "./logged.middleware.ts";
 import { AuthMiddleware } from "./auth.middleware.ts";
-import { Router, Query, Middlewares } from 'nestjs-trpc';
+import { Router, Query, UseMiddlewares } from 'nestjs-trpc';
 import { Inject } from '@nestjs/common';
 import { z } from 'zod';
 
@@ -108,7 +108,7 @@ const dogsSchema = z.object({
 export class DogsRouter {
   constructor(@Inject(DatabaseService) private databaseService: DatabaseService){}
 
-  @Middlewares(LoggedMiddleware, AuthMiddleware)
+  @UseMiddlewares(LoggedMiddleware, AuthMiddleware)
   @Query({ output: z.array(dogSchema) })
   async findAll(): string {
     const dogs = await this.databaseService.dogs.findMany();
@@ -132,7 +132,7 @@ Then you can import those types and use throughout your procedures from `nestjs-
 import type { AuthMiddlewareContext } from 'nestjs-trpc/types';
 import { UserService } from "./user.service.ts";
 import { AuthMiddleware } from "./auth.middleware.ts";
-import { Router, Query, Middlewares } from 'nestjs-trpc';
+import { Router, Query, UseMiddlewares } from 'nestjs-trpc';
 import { Inject } from '@nestjs/common';
 import { z } from 'zod';
 
@@ -146,7 +146,7 @@ const userSchema = z.object({
 export class UserRouter {
   constructor(@Inject(UserService) private userService: UserService){}
 
-  @Middlewares(AuthMiddleware)
+  @UseMiddlewares(AuthMiddleware)
   @Query({ output: userSchema })
   async getUserProfile(@Context() ctx: AuthMiddlewareContext): string {
     const { userId } = ctx.auth;
@@ -201,4 +201,4 @@ export interface AuthMiddlewareContext extends Context {
 </Tabs>
 
 #### Dependency injection
-Middlewares fully supports Dependency Injection. Just as with NestJS middlewares and guards, they are able to inject dependencies that are available within the same module. As usual, this is done through the `constructor`.
+UseMiddlewares fully supports Dependency Injection. Just as with NestJS middlewares and guards, they are able to inject dependencies that are available within the same module. As usual, this is done through the `constructor`.

--- a/docs/pages/docs/routers.mdx
+++ b/docs/pages/docs/routers.mdx
@@ -116,10 +116,10 @@ tRPC procedures may define validation logic for their input and/or output, and v
 We can pass those schemas directly to the decorator as shown above.<br/>For me information on how tRPC procedure validation works, check their <Link href={"https://trpc.io/docs/server/validators"} className="underline" target="_blank">official documentation page</Link>.
 
 ##### Middlewares
-By default every route will be assigned the `publicProcedure` base, but it is possible to use custom middlewares instead our router via the `@Middlewares()` decorator.
+By default every route will be assigned the `publicProcedure` base, but it is possible to use custom middlewares instead our router via the `@UseMiddlewares()` decorator.
 <Table columns={["Decorator", "Output"]}>
   <Table.Row>
-    <Table.Cell>`@Middlewares(middleware: TRPCMiddleware)`</Table.Cell>
+    <Table.Cell>`@UseMiddlewares(middleware: TRPCMiddleware)`</Table.Cell>
     <Table.Cell>`middleware.query()`</Table.Cell>
   </Table.Row>
 </Table>
@@ -160,7 +160,7 @@ which are available out of the box. Below is a list of the provided decorators a
 Below is an example of a UserRouter completed with most of the features and decorators mentioned above.
 ```typescript filename="user.router.ts" copy
 import { Inject } from '@nestjs/common';
-import { Router, Query, Middlewares, Input } from 'nestjs-trpc';
+import { Router, Query, UseMiddlewares, Input } from 'nestjs-trpc';
 import { UserService } from './user.service';
 import { ProtectedMiddleware } from './protected.middleware';
 import { z } from 'zod';
@@ -182,7 +182,7 @@ export class UserRouter {
     input: z.object({ userId: z.string() }),
     output: userSchema,
   })
-  @Middlewares(ProtectedMiddleware)
+  @UseMiddlewares(ProtectedMiddleware)
   async getUserById(@Input('userId') userId: string): Promise<User> {
     const user = await this.userService.getUser(userId);
 

--- a/examples/nestjs-express/src/user.router.ts
+++ b/examples/nestjs-express/src/user.router.ts
@@ -2,7 +2,7 @@ import { Inject } from '@nestjs/common';
 import {
   Router,
   Query,
-  Middlewares,
+  UseMiddlewares,
   Input,
   Ctx,
   Options,
@@ -22,7 +22,7 @@ export class UserRouter {
     input: z.object({ userId: z.string() }),
     output: userSchema,
   })
-  @Middlewares(ProtectedMiddleware)
+  @UseMiddlewares(ProtectedMiddleware)
   async getUserById(
     @Input('userId') userId: string,
     @Ctx() ctx: object,

--- a/examples/nestjs-fastify/src/user.router.ts
+++ b/examples/nestjs-fastify/src/user.router.ts
@@ -2,7 +2,7 @@ import { Inject } from '@nestjs/common';
 import {
   Router,
   Query,
-  Middlewares,
+  UseMiddlewares,
   Input,
   Ctx,
   Options,
@@ -15,7 +15,7 @@ import { TRPCError } from '@trpc/server';
 import { User, userSchema } from './user.schema';
 import { LoggingMiddleware } from './logging.middleware';
 
-@Middlewares(LoggingMiddleware)
+@UseMiddlewares(LoggingMiddleware)
 @Router({ alias: 'users' })
 export class UserRouter {
   constructor(@Inject(UserService) private readonly userService: UserService) {}
@@ -24,7 +24,7 @@ export class UserRouter {
     input: z.object({ userId: z.string() }),
     output: userSchema,
   })
-  @Middlewares(ProtectedMiddleware)
+  @UseMiddlewares(ProtectedMiddleware)
   async getUserById(
     @Input('userId') userId: string,
     @Ctx() ctx: object,

--- a/packages/nestjs-trpc/README.md
+++ b/packages/nestjs-trpc/README.md
@@ -66,7 +66,7 @@ Here's a brief example demonstrating how to use the decorators available in **Ne
 ```typescript
 // users.router.ts
 import { Inject } from '@nestjs/common';
-import { Router, Query, Middlewares } from 'trpc-nestjs';
+import { Router, Query, UseMiddlewares } from 'trpc-nestjs';
 import { UserService } from './user.service';
 import { ProtectedMiddleware } from './protected.middleware';
 import { TRPCError } from '@trpc/server';
@@ -83,7 +83,7 @@ class UserRouter {
     @Inject(UserService) private readonly userService: UserService
   ) {}
 
-  @Middlewares(ProtectedMiddleware)
+  @UseMiddlewares(ProtectedMiddleware)
   @Query({ output: z.array(userSchema) })
   async getUsers() {
     try {

--- a/packages/nestjs-trpc/lib/decorators/__tests__/middlewares.decorator.spec.ts
+++ b/packages/nestjs-trpc/lib/decorators/__tests__/middlewares.decorator.spec.ts
@@ -1,13 +1,13 @@
 import 'reflect-metadata';
-import { Middlewares } from '../middlewares.decorator';
+import { UseMiddlewares } from '../middlewares.decorator';
 import { MIDDLEWARES_KEY } from '../../trpc.constants';
 import { MiddlewareOptions, MiddlewareResponse, TRPCMiddleware } from '../../interfaces';
 
-describe('Middlewares Decorator', () => {
+describe('UseMiddlewares Decorator', () => {
   const mockMiddleware = () => ({});
 
   it('should add metadata to the class', () => {
-    @Middlewares(mockMiddleware)
+    @UseMiddlewares(mockMiddleware)
     class TestClass {}
 
     const metadata = Reflect.getMetadata(MIDDLEWARES_KEY, TestClass);
@@ -16,7 +16,7 @@ describe('Middlewares Decorator', () => {
 
   it('should add metadata to the method', () => {
     class TestClass {
-      @Middlewares(mockMiddleware)
+      @UseMiddlewares(mockMiddleware)
       testMethod() {}
     }
 
@@ -26,7 +26,7 @@ describe('Middlewares Decorator', () => {
 
   it('should throw an error for invalid middleware on class', () => {
     expect(() => {
-      @Middlewares({} as any)
+      @UseMiddlewares({} as any)
       class TestClass {}
     }).toThrow();
   });
@@ -34,7 +34,7 @@ describe('Middlewares Decorator', () => {
   it('should throw an error for invalid middleware on method', () => {
     expect(() => {
       class TestClass {
-        @Middlewares({} as any)
+        @UseMiddlewares({} as any)
         testMethod() {}
       }
     }).toThrow();
@@ -47,7 +47,7 @@ describe('Middlewares Decorator', () => {
         }
     }
 
-    @Middlewares(MiddlewareWithUse)
+    @UseMiddlewares(MiddlewareWithUse)
     class TestClass {}
 
     const metadata = Reflect.getMetadata(MIDDLEWARES_KEY, TestClass);

--- a/packages/nestjs-trpc/lib/decorators/middlewares.decorator.ts
+++ b/packages/nestjs-trpc/lib/decorators/middlewares.decorator.ts
@@ -10,13 +10,75 @@ import { validateEach } from '../utils/validate-each.util';
  * Decorator that binds middlewares to the scope of the router or a procedure,
  * depending on its context.
  *
+ * When `@UseMiddlewares` is used at the router level, the middleware will be
+ * applied to every handler (method) in the router.
+ *
+ * When `@UseMiddlewares` is used at the individual handler level, the middleware
+ * will apply only to that specific method.
+ *
+ * @param middlewares a single middleware instance or class, or a list of comma separated middleware instances
+ * or classes.
+ *
+ * @see [Middlewares](https://nestjs-trpc.io/docs/middlewares)
+ *
+ * @publicApi
+ */
+export function UseMiddlewares(
+  ...middlewares: Array<Class<TRPCMiddleware> | Constructor<TRPCMiddleware>>
+): MethodDecorator & ClassDecorator {
+  return (
+    target: any,
+    key?: string | symbol,
+    descriptor?: TypedPropertyDescriptor<any>,
+  ) => {
+    const isMiddlewareValid = (
+      middleware: Constructor<TRPCMiddleware> | Record<string, unknown>,
+    ) =>
+      middleware &&
+      (isFunction(middleware) ||
+        isFunction((middleware as Record<string, any>).use));
+
+    if (descriptor) {
+      validateEach(
+        target.constructor,
+        middlewares,
+        isMiddlewareValid,
+        '@UseMiddlewares',
+        'middleware',
+      );
+      Reflect.defineMetadata(
+        MIDDLEWARES_KEY,
+        [...middlewares],
+        descriptor.value,
+      );
+      return descriptor;
+    }
+    validateEach(
+      target.constructor,
+      middlewares,
+      isMiddlewareValid,
+      '@UseMiddlewares',
+      'middleware',
+    );
+    Reflect.defineMetadata(MIDDLEWARES_KEY, [...middlewares], target);
+    return target;
+  };
+}
+
+/**
+ * @deprecated Use `@UseMiddlewares` instead. This decorator is deprecated 
+ * in order to satisfy NestJS naming convention fe. `@UseGuards`. 
+ *
+ * Decorator that binds middlewares to the scope of the router or a procedure,
+ * depending on its context.
+ *
  * When `@Middlewares` is used at the router level, the middleware will be
  * applied to every handler (method) in the router.
  *
  * When `@Middlewares` is used at the individual handler level, the middleware
  * will apply only to that specific method.
  *
- * @param middlewares a single middleware instance or class, or a list of comma seperated middleware instances
+ * @param middlewares a single middleware instance or class, or a list of comma separated middleware instances
  * or classes.
  *
  * @see [Middlewares](https://nestjs-trpc.io/docs/middlewares)
@@ -64,3 +126,4 @@ export function Middlewares(
     return target;
   };
 }
+;

--- a/packages/nestjs-trpc/lib/factories/__tests__/procedure.factory.spec.ts
+++ b/packages/nestjs-trpc/lib/factories/__tests__/procedure.factory.spec.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { ProcedureBuilder, TRPCError, initTRPC } from '@trpc/server';
 import { ProcedureFactoryMetadata, ProcedureParamDecoratorType } from '../../interfaces/factory.interface';
 import { TRPCMiddleware } from '../../interfaces';
-import { Ctx, Input, Middlewares, Options, Query } from '../../decorators';
+import { Ctx, Input, UseMiddlewares, Options, Query } from '../../decorators';
 import { ProcedureType } from '../../trpc.enum';
 
 describe('ProcedureFactory', () => {
@@ -18,6 +18,7 @@ describe('ProcedureFactory', () => {
       providers: [
         ProcedureFactory,
         {
+          provide: ConsoleLogger,
           provide: ConsoleLogger,
           useValue: {
             log: jest.fn(),
@@ -68,7 +69,7 @@ describe('ProcedureFactory', () => {
           input: z.object({ userId: z.string() }),
           output: userSchema
         })
-        @Middlewares(ProtectedMiddleware)
+        @UseMiddlewares(ProtectedMiddleware)
         async getUserById(@Input("userId") userId: string, @Ctx() ctx: any, @Options() opts: any): Promise<any> {
           const user = await this.userService.getUser(userId);
           if (ctx.ben) {

--- a/packages/nestjs-trpc/lib/generators/__tests__/decorator.generator.spec.ts
+++ b/packages/nestjs-trpc/lib/generators/__tests__/decorator.generator.spec.ts
@@ -12,7 +12,7 @@ describe('DecoratorGenerator', () => {
   beforeEach(async () => {
     project = new Project();
     sourceFile = project.createSourceFile("test.ts", `
-      import { Query, Mutation, Middlewares } from '@nestjs/common';
+      import { Query, Mutation, UseMiddlewares } from '@nestjs/common';
       
       class TestClass {
         @Query()
@@ -21,7 +21,7 @@ describe('DecoratorGenerator', () => {
         @Mutation()
         mutationMethod() {}
 
-        @Middlewares()
+        @UseMiddlewares()
         middlewareMethod() {}
 
         @UnsupportedDecorator()
@@ -76,9 +76,9 @@ describe('DecoratorGenerator', () => {
       expect(result).toEqual([{ name: 'Mutation', arguments: {} }]);
     });
 
-    it('should ignore Middlewares decorator', () => {
+    it('should ignore UseMiddlewares decorator', () => {
       const middlewareMethod = sourceFile.getClass('TestClass')!.getMethod('middlewareMethod')!;
-      const middlewaresDecorator = middlewareMethod.getDecorator('Middlewares')!;
+      const middlewaresDecorator = middlewareMethod.getDecorator('UseMiddlewares')!;
 
       const result = decoratorGenerator.serializeProcedureDecorators(
         [middlewaresDecorator],

--- a/packages/nestjs-trpc/lib/generators/decorator.generator.ts
+++ b/packages/nestjs-trpc/lib/generators/decorator.generator.ts
@@ -47,7 +47,7 @@ export class DecoratorGenerator {
               ...(output ? { output } : {}),
             },
           });
-        } else if (decoratorName === 'Middlewares') {
+        } else if (decoratorName === 'UseMiddlewares') {
           return array;
         } else {
           this.consoleLogger.warn(`Decorator ${decoratorName}, not supported.`);

--- a/packages/nestjs-trpc/lib/generators/decorator.generator.ts
+++ b/packages/nestjs-trpc/lib/generators/decorator.generator.ts
@@ -47,7 +47,7 @@ export class DecoratorGenerator {
               ...(output ? { output } : {}),
             },
           });
-        } else if (decoratorName === 'UseMiddlewares') {
+        } else if (decoratorName === 'UseMiddlewares' || decoratorName === 'Middlewares') {
           return array;
         } else {
           this.consoleLogger.warn(`Decorator ${decoratorName}, not supported.`);


### PR DESCRIPTION
Sadly I cannot check if it works, because I'm getting `Cannot find module 'nestjs-trpc' or its corresponding type declarations.` error inside examples.

I also changed every mention about `@Middlewares` decorator inside documentation and examples to use newer version.