### PR TITLE
fix(packages/nestjs-trpc): removed ts file generation dependencies when not generating files.

### DIFF
--- a/examples/nestjs-express/src/app.module.ts
+++ b/examples/nestjs-express/src/app.module.ts
@@ -9,7 +9,8 @@ import { TrpcPanelController } from './trpc-panel.controller';
 @Module({
   imports: [
     TRPCModule.forRoot({
-      autoSchemaFile: './src/@generated',
+      autoSchemaFile:
+        process.env.NODE_ENV === 'production' ? undefined : './src/@generated',
       context: AppContext,
     }),
   ],

--- a/packages/nestjs-trpc/lib/generators/generator.interface.ts
+++ b/packages/nestjs-trpc/lib/generators/generator.interface.ts
@@ -1,0 +1,9 @@
+import type { SchemaImports, TRPCContext } from '../interfaces';
+import type { Class } from 'type-fest';
+
+export interface GeneratorModuleOptions {
+  rootModuleFilePath: string;
+  context?: Class<TRPCContext>;
+  outputDirPath?: string;
+  schemaFileImports?: Array<SchemaImports>;
+}

--- a/packages/nestjs-trpc/lib/generators/trpc.generator.ts
+++ b/packages/nestjs-trpc/lib/generators/trpc.generator.ts
@@ -72,7 +72,6 @@ export class TRPCGenerator implements OnModuleInit {
   }
 
   public async generateSchemaFile(
-    outputDirPath: string,
     schemaImports?: Array<SchemaImports> | undefined,
   ): Promise<void> {
     try {

--- a/packages/nestjs-trpc/lib/trpc.constants.ts
+++ b/packages/nestjs-trpc/lib/trpc.constants.ts
@@ -1,5 +1,6 @@
 export const TRPC_MODULE_OPTIONS = 'TrpcModuleOptions';
 
+export const TRPC_GENERATOR_OPTIONS = 'TrpcGenderOptions';
 export const TRPC_MODULE_CALLER_FILE_PATH = 'TrpcModuleCallerFilePath';
 
 export const ROUTER_METADATA_KEY = Symbol('trpc:router_type');

--- a/packages/nestjs-trpc/lib/trpc.driver.ts
+++ b/packages/nestjs-trpc/lib/trpc.driver.ts
@@ -5,7 +5,6 @@ import type { FastifyInstance as FastifyApplication } from 'fastify';
 import { TRPCContext, TRPCModuleOptions } from './interfaces';
 import { AnyRouter, initTRPC } from '@trpc/server';
 import { TRPCFactory } from './factories/trpc.factory';
-import { TRPCGenerator } from './generators/trpc.generator';
 import { AppRouterHost } from './app-router.host';
 import { ExpressDriver, FastifyDriver } from './drivers';
 
@@ -39,9 +38,6 @@ export class TRPCDriver<
 
   @Inject(TRPCFactory)
   protected readonly trpcFactory!: TRPCFactory;
-
-  @Inject(TRPCGenerator)
-  protected readonly trpcGenerator!: TRPCGenerator;
 
   @Inject(ConsoleLogger)
   protected readonly consoleLogger!: ConsoleLogger;
@@ -94,19 +90,6 @@ export class TRPCDriver<
       await this.fastifyDriver.start(options, app, appRouter, contextInstance);
     } else {
       throw new Error(`Unsupported http adapter: ${platformName}`);
-    }
-
-    if (options.autoSchemaFile != null) {
-      await this.trpcGenerator.generateSchemaFile(
-        options.autoSchemaFile,
-        options.schemaFileImports,
-      );
-      await this.trpcGenerator.generateHelpersFile(options.context);
-    } else {
-      this.consoleLogger.log(
-        'Skipping appRouter types generation - `autoSchemaFile` was not provided.',
-        'TRPC Driver',
-      );
     }
   }
 }


### PR DESCRIPTION
This PR removes the schema generation dependencies if schema generation is disabled.
We do this by conditionally including the `GeneratorModule` based on the provided `autoSchemaFile` option.
