### PR TITLE
(Chore) Fix Tests + Improve Tooling for Testing

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,29 @@
+name: verify
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    name: verify
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          submodules: false
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Lint
+        run: yarn lint --no-fix
+      - name: Test
+        run: yarn test
+      - name: Build
+        run: yarn build

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,7 @@ const compat = new FlatCompat({
 export default [{
     ignores: [
         "packages/**/tests/**",
+        "packages/**/dist/**",
         "examples",
         "dist",
         "node_modules",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "clean": "tsc -b --clean",
     "format": "prettier packages/**/*.ts --ignore-path ./.prettierignore --write",
     "lint": "eslint 'packages/**/*.ts' --fix",
+    "test": "yarn workspaces foreach --all run test",
     "release": "release-it",
     "prepublish:npm": "yarn build && yarn changelog | pbcopy",
     "publish:npm": "lerna publish",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
   "lint-staged": {
     "*.ts": [
       "prettier --write",
-      "eslint --fix"
+      "eslint --fix",
+      "yarn test --bail --findRelatedTests"
     ]
   },
   "repository": {

--- a/packages/nestjs-trpc/lib/decorators/__tests__/middlewares.decorator.spec.ts
+++ b/packages/nestjs-trpc/lib/decorators/__tests__/middlewares.decorator.spec.ts
@@ -4,24 +4,28 @@ import { MIDDLEWARES_KEY } from '../../trpc.constants';
 import { MiddlewareOptions, MiddlewareResponse, TRPCMiddleware } from '../../interfaces';
 
 describe('UseMiddlewares Decorator', () => {
-  const mockMiddleware = () => ({});
+  class TestMiddleware implements TRPCMiddleware {
+    use(opts: MiddlewareOptions<object>): MiddlewareResponse | Promise<MiddlewareResponse> {
+      throw new Error('Method not implemented.');
+    }
+  }
 
   it('should add metadata to the class', () => {
-    @UseMiddlewares(mockMiddleware)
+    @UseMiddlewares(TestMiddleware)
     class TestClass {}
 
     const metadata = Reflect.getMetadata(MIDDLEWARES_KEY, TestClass);
-    expect(metadata).toBe(mockMiddleware);
+    expect(metadata).toStrictEqual([TestMiddleware]);
   });
 
   it('should add metadata to the method', () => {
     class TestClass {
-      @UseMiddlewares(mockMiddleware)
+      @UseMiddlewares(TestMiddleware)
       testMethod() {}
     }
 
     const metadata = Reflect.getMetadata(MIDDLEWARES_KEY, TestClass.prototype.testMethod);
-    expect(metadata).toBe(mockMiddleware);
+    expect(metadata).toStrictEqual([TestMiddleware]);
   });
 
   it('should throw an error for invalid middleware on class', () => {
@@ -38,19 +42,5 @@ describe('UseMiddlewares Decorator', () => {
         testMethod() {}
       }
     }).toThrow();
-  });
-
-  it('should accept middleware with use method', () => {
-    class MiddlewareWithUse implements TRPCMiddleware{
-        use(opts: MiddlewareOptions<object>): MiddlewareResponse | Promise<MiddlewareResponse> {
-            throw new Error('Method not implemented.');
-        }
-    }
-
-    @UseMiddlewares(MiddlewareWithUse)
-    class TestClass {}
-
-    const metadata = Reflect.getMetadata(MIDDLEWARES_KEY, TestClass);
-    expect(metadata).toBe(MiddlewareWithUse);
   });
 });

--- a/packages/nestjs-trpc/lib/decorators/__tests__/router.decorator.spec.ts
+++ b/packages/nestjs-trpc/lib/decorators/__tests__/router.decorator.spec.ts
@@ -8,7 +8,7 @@ describe('Router Decorator', () => {
     class TestRouter {}
 
     const metadata = Reflect.getMetadata(ROUTER_METADATA_KEY, TestRouter);
-    expect(metadata).toEqual({ alias: undefined });
+    expect(metadata).toStrictEqual({alias: undefined, path: __filename})
   });
 
   it('should set router metadata with alias', () => {
@@ -18,7 +18,7 @@ describe('Router Decorator', () => {
     class TestRouter {}
 
     const metadata = Reflect.getMetadata(ROUTER_METADATA_KEY, TestRouter);
-    expect(metadata).toEqual({ alias });
+    expect(metadata).toStrictEqual({alias, path: __filename})
   });
 
   it('should not affect class methods', () => {
@@ -41,7 +41,7 @@ describe('Router Decorator', () => {
     const metadata1 = Reflect.getMetadata(ROUTER_METADATA_KEY, TestRouter1);
     const metadata2 = Reflect.getMetadata(ROUTER_METADATA_KEY, TestRouter2);
 
-    expect(metadata1).toEqual({ alias: 'router1' });
-    expect(metadata2).toEqual({ alias: 'router2' });
+    expect(metadata1).toEqual({ alias: 'router1', path: __filename });
+    expect(metadata2).toEqual({ alias: 'router2', path: __filename });
   });
 });

--- a/packages/nestjs-trpc/lib/decorators/context.decorator.ts
+++ b/packages/nestjs-trpc/lib/decorators/context.decorator.ts
@@ -6,7 +6,7 @@ import { PROCEDURE_PARAM_METADATA_KEY } from '../trpc.constants';
 
 export function Ctx(): ParameterDecorator {
   return (
-    target: Object,
+    target: object,
     propertyKey: string | symbol | undefined,
     parameterIndex?: number | TypedPropertyDescriptor<any>,
   ) => {

--- a/packages/nestjs-trpc/lib/decorators/middlewares.decorator.ts
+++ b/packages/nestjs-trpc/lib/decorators/middlewares.decorator.ts
@@ -66,8 +66,8 @@ export function UseMiddlewares(
 }
 
 /**
- * @deprecated Use `@UseMiddlewares` instead. This decorator is deprecated 
- * in order to satisfy NestJS naming convention fe. `@UseGuards`. 
+ * @deprecated Use `@UseMiddlewares` instead. This decorator is deprecated
+ * in order to satisfy NestJS naming convention fe. `@UseGuards`.
  *
  * Decorator that binds middlewares to the scope of the router or a procedure,
  * depending on its context.
@@ -126,4 +126,3 @@ export function Middlewares(
     return target;
   };
 }
-;

--- a/packages/nestjs-trpc/lib/factories/__tests__/middleware.factory.spec.ts
+++ b/packages/nestjs-trpc/lib/factories/__tests__/middleware.factory.spec.ts
@@ -38,7 +38,7 @@ describe('MiddlewareFactory', () => {
 
   describe('getMiddlewares', () => {
     it('should return unique middlewares', () => {
-      const mockRouter = { instance: {}, prototype: {} };
+      const mockRouter = { instance: {}, prototype: {}, middlewares: [] };
       const mockProcedure = { middlewares: [class TestMiddleware {}] };
       
       (routerFactory.getRouters as jest.Mock).mockReturnValue([mockRouter]);
@@ -47,11 +47,11 @@ describe('MiddlewareFactory', () => {
       const result = middlewareFactory.getMiddlewares();
 
       expect(result).toHaveLength(1);
-      expect(result[0]).toBe(mockProcedure.middlewares[0]);
+      expect(result[0]).toStrictEqual({"instance": mockProcedure.middlewares[0], "path": undefined });
     });
 
     it('should handle procedures without middlewares', () => {
-      const mockRouter = { instance: {}, prototype: {} };
+      const mockRouter = { instance: {}, prototype: {}, middlewares: []  };
       const mockProcedure = { middlewares: undefined };
       
       (routerFactory.getRouters as jest.Mock).mockReturnValue([mockRouter]);

--- a/packages/nestjs-trpc/lib/factories/__tests__/router.factory.spec.ts
+++ b/packages/nestjs-trpc/lib/factories/__tests__/router.factory.spec.ts
@@ -119,7 +119,8 @@ describe('RouterFactory', () => {
         name: 'UserRouter',
         instance: userRouterInstance,
         alias: 'users',
-        middlewares: undefined,
+        middlewares: [],
+        path: undefined,
       });
     });
   });
@@ -214,7 +215,7 @@ describe('RouterFactory', () => {
         userRouterInstance,
         'users',
         mockProcedureBuilder,
-        undefined
+        []
       );
     });
   });

--- a/packages/nestjs-trpc/lib/factories/middleware.factory.ts
+++ b/packages/nestjs-trpc/lib/factories/middleware.factory.ts
@@ -30,7 +30,7 @@ export class MiddlewareFactory {
       );
 
       const procedureMiddleware = procedures.flatMap((procedure) => {
-        return procedure.middlewares != null ? procedure.middlewares : [];
+        return procedure.middlewares ?? [];
       });
 
       return [...middlewares, ...procedureMiddleware].map((middleware) => ({

--- a/packages/nestjs-trpc/lib/generators/__tests__/context.generator.spec.ts
+++ b/packages/nestjs-trpc/lib/generators/__tests__/context.generator.spec.ts
@@ -3,10 +3,6 @@ import { ContextGenerator } from '../context.generator';
 import { Project, SourceFile } from 'ts-morph';
 import { TRPCContext } from '../../interfaces';
 
-jest.mock('func-loc', () => ({
-  locate: jest.fn().mockResolvedValue({ path: 'test.ts' }),
-}));
-
 describe('ContextGenerator', () => {
   let contextGenerator: ContextGenerator;
   let project: Project;
@@ -39,10 +35,6 @@ describe('ContextGenerator', () => {
   });
 
   describe('getContextInterface', () => {
-    it('should return null if context class name is not defined', async () => {
-      const result = await contextGenerator.getContextInterface({} as any, project);
-      expect(result).toBeNull();
-    });
 
     it('should return the context interface if everything is valid', async () => {
       class TestContext implements TRPCContext {
@@ -53,7 +45,7 @@ describe('ContextGenerator', () => {
 
       jest.spyOn(project, 'addSourceFileAtPath').mockReturnValue(sourceFile);
 
-      const result = await contextGenerator.getContextInterface(TestContext, project);
+      const result = await contextGenerator.getContextInterface(sourceFile, TestContext);
       expect(result).toBe('{ user: { id: string; name: string; }; }');
     });
 
@@ -71,8 +63,8 @@ describe('ContextGenerator', () => {
 
       jest.spyOn(project, 'addSourceFileAtPath').mockReturnValue(sourceFile);
 
-      //@ts-expect-error
-      const result = await contextGenerator.getContextInterface(InvalidContext, project);
+      //@ts-expect-error invalid context passed in
+      const result = await contextGenerator.getContextInterface(sourceFile, InvalidContext);
       expect(result).toBeNull();
     });
   });

--- a/packages/nestjs-trpc/lib/generators/__tests__/decorator.generator.spec.ts
+++ b/packages/nestjs-trpc/lib/generators/__tests__/decorator.generator.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { DecoratorGenerator } from '../decorator.generator';
 import { ConsoleLogger } from '@nestjs/common';
 import { Project, SourceFile } from 'ts-morph';
+import { ProcedureGenerator } from '../procedure.generator';
 
 describe('DecoratorGenerator', () => {
   let decoratorGenerator: DecoratorGenerator;
@@ -34,6 +35,12 @@ describe('DecoratorGenerator', () => {
         DecoratorGenerator,
         {
           provide: ConsoleLogger,
+          useValue: {
+            warn: jest.fn(),
+          },
+        },
+        {
+          provide: ProcedureGenerator,
           useValue: {
             warn: jest.fn(),
           },

--- a/packages/nestjs-trpc/lib/generators/__tests__/middleware.generator.spec.ts
+++ b/packages/nestjs-trpc/lib/generators/__tests__/middleware.generator.spec.ts
@@ -3,10 +3,6 @@ import { MiddlewareGenerator } from '../middleware.generator';
 import { Project, SourceFile } from 'ts-morph';
 import { TRPCMiddleware } from '../../interfaces';
 
-jest.mock('func-loc', () => ({
-  locate: jest.fn().mockResolvedValue({ path: 'test.ts' }),
-}));
-
 describe('MiddlewareGenerator', () => {
   let middlewareGenerator: MiddlewareGenerator;
   let project: Project;
@@ -45,7 +41,7 @@ describe('MiddlewareGenerator', () => {
 
   describe('getMiddlewareInterface', () => {
     it('should return null if middleware class name is not defined', async () => {
-      const result = await middlewareGenerator.getMiddlewareInterface({} as any, project);
+      const result = await middlewareGenerator.getMiddlewareInterface('routerPath', {} as any, project);
       expect(result).toBeNull();
     });
 
@@ -62,7 +58,7 @@ describe('MiddlewareGenerator', () => {
 
       jest.spyOn(project, 'addSourceFileAtPath').mockReturnValue(sourceFile);
 
-      const result = await middlewareGenerator.getMiddlewareInterface(TestMiddleware, project);
+      const result = await middlewareGenerator.getMiddlewareInterface('routerPath', TestMiddleware, project);
       expect(result).toEqual({
         name: 'TestMiddleware',
         properties: [

--- a/packages/nestjs-trpc/lib/generators/__tests__/procedure.generator.spec.ts
+++ b/packages/nestjs-trpc/lib/generators/__tests__/procedure.generator.spec.ts
@@ -1,0 +1,72 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Project } from 'ts-morph';
+import {
+  ProcedureGeneratorMetadata,
+} from '../../interfaces/generator.interface';
+import { ProcedureGenerator } from '../procedure.generator';
+import { ImportsScanner } from '../../scanners/imports.scanner';
+import { StaticGenerator } from '../static.generator';
+import { TYPESCRIPT_APP_ROUTER_SOURCE_FILE } from '../generator.constants';
+
+describe('ProcedureGenerator', () => {
+  let procedureGenerator: ProcedureGenerator;
+  let project: Project;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProcedureGenerator,
+        {
+          provide: ImportsScanner,
+          useValue: jest.fn(),
+        },
+        {
+          provide: StaticGenerator,
+          useValue: jest.fn(),
+        },
+        {
+          provide: TYPESCRIPT_APP_ROUTER_SOURCE_FILE,
+          useValue: jest.fn(),
+        },
+      ],
+    }).compile();
+
+    procedureGenerator = module.get<ProcedureGenerator>(ProcedureGenerator);
+  });
+
+  it('should be defined', () => {
+    expect(procedureGenerator).toBeDefined();
+  });
+
+  describe('generateRoutersStringFromMetadata', () => {
+    describe('for a query', () => {
+      it('should generate router string from metadata', () => {
+        const mockProcedure: ProcedureGeneratorMetadata = {
+          name: 'testQuery',
+          decorators: [{ name: 'Query', arguments: {} }],
+        }
+
+        const result = procedureGenerator.generateProcedureString(mockProcedure);
+
+        expect(result).toBe(
+          'testQuery: publicProcedure.query(async () => "PLACEHOLDER_DO_NOT_REMOVE" as any )'
+        );
+      });
+    })
+
+    describe('for a mutation', () => {
+      it('should generate router string from metadata', () => {
+        const mockProcedure: ProcedureGeneratorMetadata = {
+          name: 'testMutation',
+          decorators: [{ name: 'Mutation', arguments: {} }],
+        }
+
+        const result = procedureGenerator.generateProcedureString(mockProcedure);
+
+        expect(result).toBe(
+          'testMutation: publicProcedure.mutation(async () => "PLACEHOLDER_DO_NOT_REMOVE" as any )'
+        );
+      });
+    })
+  });
+});

--- a/packages/nestjs-trpc/lib/generators/__tests__/trpc.generator.spec.ts
+++ b/packages/nestjs-trpc/lib/generators/__tests__/trpc.generator.spec.ts
@@ -7,11 +7,16 @@ import { ContextGenerator } from '../context.generator';
 import { RouterFactory } from '../../factories/router.factory';
 import { MiddlewareFactory } from '../../factories/middleware.factory';
 import { ProcedureFactory } from '../../factories/procedure.factory';
-import { Project, SourceFile } from 'ts-morph';
+import { ClassDeclaration, Project, SourceFile } from 'ts-morph';
 import * as fileUtil from '../../utils/ts-morph.util';
 import { ProcedureFactoryMetadata } from '../../interfaces/factory.interface';
 import { MiddlewareOptions, MiddlewareResponse, TRPCContext, TRPCMiddleware } from '../../interfaces';
 import { CreateExpressContextOptions } from '@trpc/server/adapters/express';
+import { TRPC_GENERATOR_OPTIONS, TRPC_MODULE_CALLER_FILE_PATH } from '../../trpc.constants';
+import { TYPESCRIPT_APP_ROUTER_SOURCE_FILE, TYPESCRIPT_PROJECT } from '../generator.constants';
+import { StaticGenerator } from '../static.generator';
+import { ImportsScanner } from '../../scanners/imports.scanner';
+import { SourceFileImportsMap } from '../../interfaces/generator.interface';
 
 jest.mock('../../utils/ts-morph.util');
 
@@ -24,10 +29,14 @@ describe('TRPCGenerator', () => {
   let routerFactory: jest.Mocked<RouterFactory>;
   let middlewareFactory: jest.Mocked<MiddlewareFactory>;
   let procedureFactory: jest.Mocked<ProcedureFactory>;
+  let importScanner: jest.Mocked<ImportsScanner>;
   let project: Project;
   let sourceFile: SourceFile;
 
   beforeEach(async () => {
+    project = new Project();
+    sourceFile = project.createSourceFile("test.ts", "", {overwrite: true});
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TRPCGenerator,
@@ -58,6 +67,13 @@ describe('TRPCGenerator', () => {
           },
         },
         {
+          provide: StaticGenerator,
+          useValue: {
+            generateStaticDeclaration: jest.fn(),
+            addSchemaImports: jest.fn(),
+          },
+        },
+        {
           provide: RouterFactory,
           useValue: {
             getRouters: jest.fn(),
@@ -75,6 +91,23 @@ describe('TRPCGenerator', () => {
             getProcedures: jest.fn(),
           },
         },
+        {
+          provide: ImportsScanner,
+          useValue: {
+            buildSourceFileImportsMap: jest.fn(),
+            resolveBarrelFileImport: jest.fn(),
+          },
+        },
+
+        { provide: TYPESCRIPT_PROJECT, useValue: project },
+        {
+          provide: TRPC_MODULE_CALLER_FILE_PATH,
+          useValue: sourceFile.getFilePath(),
+        },
+        {
+          provide: TYPESCRIPT_APP_ROUTER_SOURCE_FILE,
+          useValue: sourceFile,
+        },
       ],
     }).compile();
 
@@ -86,12 +119,7 @@ describe('TRPCGenerator', () => {
     routerFactory = module.get(RouterFactory);
     middlewareFactory = module.get(MiddlewareFactory);
     procedureFactory = module.get(ProcedureFactory);
-
-    project = new Project();
-    sourceFile = project.createSourceFile("test.ts", "", {overwrite: true});
-
-    // Call onModuleInit to set up the project
-    trpcGenerator.onModuleInit();
+    importScanner = module.get(ImportsScanner);
   });
 
   it('should be defined', () => {
@@ -100,27 +128,27 @@ describe('TRPCGenerator', () => {
 
   describe('generateSchemaFile', () => {
     it('should generate schema file', async () => {
-      const mockRouters = [{ name: 'TestRouter', instance: {}, alias: 'test' }];
+      const mockRouters = [{ name: 'TestRouter', instance: {}, alias: 'test', path: 'testPath', middlewares: [] }];
       const mockProcedures: Array<ProcedureFactoryMetadata> = [{ 
         name: 'testProcedure', 
         implementation: jest.fn(), 
         type: "query", 
         input: undefined,
         output: undefined,
-        params: [] 
+        params: [],
+        middlewares: [],
       }];
-      const mockRoutesAndProcedures = [{ name: 'TestRouter', alias: 'test', procedures: mockProcedures }];
-      const mockRoutersMetadata = [{ name: 'TestRouter', alias: 'test', procedures: [{ name: 'testProcedure', decorators: [] }] }];
+      const mockRoutersMetadata = [{ name: 'TestRouter', alias: 'test', procedures: [{ name: 'testProcedure', decorators: [] }], path: 'testPath'}];
 
       routerFactory.getRouters.mockReturnValue(mockRouters);
       procedureFactory.getProcedures.mockReturnValue(mockProcedures);
-      routerGenerator.serializeRouters.mockResolvedValue(mockRoutersMetadata);
+      routerGenerator.serializeRouters.mockReturnValue(mockRoutersMetadata);
       routerGenerator.generateRoutersStringFromMetadata.mockReturnValue('test: t.router({})');
 
       jest.spyOn(project, 'createSourceFile').mockReturnValue(sourceFile);
       (fileUtil.saveOrOverrideFile as jest.Mock).mockResolvedValue(undefined);
 
-      await trpcGenerator.generateSchemaFile('/output/path');
+      await trpcGenerator.generateSchemaFile([{name: '/output/path'}]);
 
       expect(routerFactory.getRouters).toHaveBeenCalled();
       expect(procedureFactory.getProcedures).toHaveBeenCalled();
@@ -128,7 +156,7 @@ describe('TRPCGenerator', () => {
       expect(routerGenerator.generateRoutersStringFromMetadata).toHaveBeenCalledWith(mockRoutersMetadata);
       expect(fileUtil.saveOrOverrideFile).toHaveBeenCalled();
       expect(consoleLogger.log).toHaveBeenCalledWith(
-        'AppRouter has been updated successfully at "/output/path/server.ts".',
+        'AppRouter has been updated successfully at "./test.ts".',
         'TRPC Generator'
       );
     });
@@ -138,7 +166,7 @@ describe('TRPCGenerator', () => {
         throw new Error('Test error');
       });
 
-      await trpcGenerator.generateSchemaFile('/output/path');
+      await trpcGenerator.generateSchemaFile([{name: '/output/path'}]);
 
       expect(consoleLogger.warn).toHaveBeenCalledWith('TRPC Generator encountered an error.', expect.any(Error));
     });
@@ -151,24 +179,33 @@ describe('TRPCGenerator', () => {
           throw new Error('Method not implemented.');
         }
       }
-      const mockMiddlewares = [TestMiddleware];
-      const mockMiddlewareInterface = { name: 'TestMiddleware', properties: [{ name: 'test', type: 'string' }] };
-
-      middlewareFactory.getMiddlewares.mockReturnValue(mockMiddlewares);
-      middlewareGenerator.getMiddlewareInterface.mockResolvedValue(mockMiddlewareInterface);
-      contextGenerator.getContextInterface.mockResolvedValue('{ user: string }');
-
-      jest.spyOn(project, 'createSourceFile').mockReturnValue(sourceFile);
-      (fileUtil.saveOrOverrideFile as jest.Mock).mockResolvedValue(undefined);
-
       class TestContext implements TRPCContext {
         create(opts: CreateExpressContextOptions): Record<string, unknown> | Promise<Record<string, unknown>> {
           throw new Error('Method not implemented.');
         }
       }
 
+      const mockMiddlewares = [{ instance: TestMiddleware, path: 'testPath' }];
+      const mockMiddlewareInterface = { name: 'TestMiddleware', properties: [{ name: 'test', type: 'string' }] };
+      const mockImportsMap = new Map<string, SourceFileImportsMap>([
+        [TestContext.name, {sourceFile, initializer: sourceFile.getClass(TestContext.name) as ClassDeclaration}]
+      ])
+
+      middlewareFactory.getMiddlewares.mockReturnValue(mockMiddlewares);
+      middlewareGenerator.getMiddlewareInterface.mockResolvedValue(mockMiddlewareInterface);
+      contextGenerator.getContextInterface.mockResolvedValue('{ user: string }');
+      // importScanner.buildSourceFileImportsMap.mockImplementation((arg) => { console.log('arg:', arg); return mockImportsMap; })
+      importScanner.buildSourceFileImportsMap.mockReturnValue(mockImportsMap);
+
+      // Call onModuleInit to set up the project
+      trpcGenerator.onModuleInit();
+
+      jest.spyOn(project, 'createSourceFile').mockReturnValue(sourceFile);
+      (fileUtil.saveOrOverrideFile as jest.Mock).mockResolvedValue(undefined);
+
       await trpcGenerator.generateHelpersFile(TestContext);
 
+      expect(importScanner.buildSourceFileImportsMap).toHaveBeenCalled();
       expect(middlewareFactory.getMiddlewares).toHaveBeenCalled();
       expect(contextGenerator.getContextInterface).toHaveBeenCalled();
       expect(middlewareGenerator.getMiddlewareInterface).toHaveBeenCalled();

--- a/packages/nestjs-trpc/lib/generators/decorator.generator.ts
+++ b/packages/nestjs-trpc/lib/generators/decorator.generator.ts
@@ -47,7 +47,10 @@ export class DecoratorGenerator {
               ...(output ? { output } : {}),
             },
           });
-        } else if (decoratorName === 'UseMiddlewares' || decoratorName === 'Middlewares') {
+        } else if (
+          decoratorName === 'UseMiddlewares' ||
+          decoratorName === 'Middlewares'
+        ) {
           return array;
         } else {
           this.consoleLogger.warn(`Decorator ${decoratorName}, not supported.`);

--- a/packages/nestjs-trpc/lib/trpc.driver.ts
+++ b/packages/nestjs-trpc/lib/trpc.driver.ts
@@ -59,7 +59,9 @@ export class TRPCDriver<
       ...(options.transformer != null
         ? { transformer: options.transformer }
         : {}),
-      ...(options.errorFormatter != null ? { errorFormatter: options.errorFormatter } : {}),
+      ...(options.errorFormatter != null
+        ? { errorFormatter: options.errorFormatter }
+        : {}),
     });
 
     const appRouter: AnyRouter = this.trpcFactory.serializeAppRoutes(

--- a/packages/nestjs-trpc/tsconfig.spec.json
+++ b/packages/nestjs-trpc/tsconfig.spec.json
@@ -4,6 +4,7 @@
     "experimentalDecorators": true,
     "sourceMap": true,
     "outDir": "./dist/tests",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "emitDecoratorMetadata": true
   }
 }


### PR DESCRIPTION
# Summary
Fix tests and add tooling to help promote them being maintained going forward.

# Details
The changes here:
1. Fix failing tests
2. Added a script to support `yarn test`
3. Added test running to `lint-staged` to tie it into pre-commit hook checks
4. Added a github action to validate PR's which includes linting, testing, and building ([test run](https://github.com/mrosnerr/nestjs-trpc/actions/runs/12216936478/job/34080569157) (see call out re. failure below))


## Call outs

1. The only test that still fails is [router.decorator.spec.ts](https://github.com/KevinEdry/nestjs-trpc/blob/c4e45b453c47f526b2b8e094b77feac9a21e42dc/packages/nestjs-trpc/lib/decorators/__tests__/router.decorator.spec.ts) which requires the change from #47 merged to pass (tested locally)
2. I made my own comments on the code with things I though would be noteworthy on top of conforming tests to the current functionality

Happy to make any adjustments or talk through the changes below - cheers 🍻