### PR TITLE
Fix context helper file generation

### DIFF
--- a/packages/nestjs-trpc/lib/generators/trpc.generator.ts
+++ b/packages/nestjs-trpc/lib/generators/trpc.generator.ts
@@ -29,7 +29,7 @@ import * as process from 'node:process';
 export class TRPCGenerator implements OnModuleInit {
   private rootModuleImportsMap!: Map<string, SourceFileImportsMap>;
   private readonly HELPER_TYPES_OUTPUT_FILE = 'index.ts';
-  private readonly HELPER_TYPES_OUTPUT_PATH = path.join(__dirname, 'types');
+  private readonly HELPER_TYPES_OUTPUT_PATH = path.join(__dirname, '..', 'types');
 
   @Inject(TRPC_MODULE_CALLER_FILE_PATH)
   private readonly moduleCallerFilePath!: string;

--- a/packages/nestjs-trpc/package.json
+++ b/packages/nestjs-trpc/package.json
@@ -13,6 +13,11 @@
       "import": "./dist/index.js",
       "require": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./types": {
+      "import": "./dist/types/index.js",
+      "require": "./dist/types/index.js",
+      "types": "./dist/types/index.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
Right now, the example in the documentation does not work because the types export was removed from the package.json and even if that is added back, the generation of the helper file is being done in the generators folder because of `__dirname`

fixes #54, fixes #21