### PR TITLE
Ting/fix generator for chained calls

### DIFF
--- a/packages/nestjs-trpc/lib/generators/__tests__/__snapshots__/procedure.generator.spec.ts.snap
+++ b/packages/nestjs-trpc/lib/generators/__tests__/__snapshots__/procedure.generator.spec.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProcedureGenerator flattenZodSchema should flatten all chained call expressions 1`] = `
+"z.object({
+          options: z
+            .object({
+              userId: z.string().describe('ID of the current user'),
+              type1: z
+          .enum(['Normal', 'Unknown'])
+          .describe('Type of the item').optional().describe('Type 1 of the item')
+            })
+            .merge({
+              z.object({
+                type2: z
+          .enum(['Normal', 'Unknown'])
+          .describe('Type of the item').optional().describe('Type 2 of the item')
+              })
+            })
+            .describe('Options to find many items'),
+        })"
+`;

--- a/packages/nestjs-trpc/lib/generators/procedure.generator.ts
+++ b/packages/nestjs-trpc/lib/generators/procedure.generator.ts
@@ -132,6 +132,7 @@ export class ProcedureGenerator {
           importsMap,
         );
       }
+
       for (const arg of node.getArguments()) {
         const argText = arg.getText();
         schema = schema.replace(

--- a/packages/nestjs-trpc/lib/generators/procedure.generator.ts
+++ b/packages/nestjs-trpc/lib/generators/procedure.generator.ts
@@ -132,13 +132,22 @@ export class ProcedureGenerator {
           importsMap,
         );
       }
-
       for (const arg of node.getArguments()) {
         const argText = arg.getText();
         schema = schema.replace(
           argText,
           this.flattenZodSchema(arg, sourceFile, project, argText),
         );
+      }
+
+      for (const child of expression.getChildren()) {
+        if (Node.isCallExpression(child)) {
+          const childText = child.getText();
+          schema = schema.replace(
+            childText,
+            this.flattenZodSchema(child, sourceFile, project, childText),
+          );
+        }
       }
     } else if (Node.isPropertyAccessExpression(node)) {
       schema = this.flattenZodSchema(


### PR DESCRIPTION
This fix solves an issue of properly flattening zod schemas referenced in chained function calls.

An example: 

```typescript
import { z } from 'zod';

const TypeEnum = z
  .enum(['Normal', 'Unknown'])
  .describe('Type of the item');

const FindManyInput = z.object({
  options: z
    .object({
      userId: z.string().describe('ID of the current user'),
      type1: TypeEnum.optional().describe('Type 1 of the item')
    })
    .merge({
      z.object({
        type2: TypeEnum.optional().describe('Type 2 of the item')
      })
    })
    .describe('Options to find many items'),
});
```

Before the fix, references to `TypeEnum` are not flattened in `FindManyInput` because it's referenced as parameters of the `object()` and `merge()` calls instead of the last `describe()` call.

After the fix, The `TypeEnum` schema is properly flattened in all places that reference it.