### PR TITLE
Fix flattening zod schema - chained calls, enum value, tsConfigFilePath

### DIFF
--- a/packages/nestjs-trpc/lib/generators/__tests__/__snapshots__/procedure.generator.spec.ts.snap
+++ b/packages/nestjs-trpc/lib/generators/__tests__/__snapshots__/procedure.generator.spec.ts.snap
@@ -19,3 +19,14 @@ exports[`ProcedureGenerator flattenZodSchema should flatten all chained call exp
             .describe('Options to find many items'),
         })"
 `;
+
+exports[`ProcedureGenerator flattenZodSchema should flatten enum to literal value 1`] = `
+"z.object({
+          options: z
+            .object({
+              userId: z.string().describe('ID of the current user'),
+              type: z.literal('Normal').describe('Type of the item')
+            })
+            .describe('Options to find many items'),
+        })"
+`;

--- a/packages/nestjs-trpc/lib/generators/__tests__/__snapshots__/procedure.generator.spec.ts.snap
+++ b/packages/nestjs-trpc/lib/generators/__tests__/__snapshots__/procedure.generator.spec.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProcedureGenerator flattenZodSchema should flatten all chained call expressions 1`] = `
+"z.object({
+          options: z
+            .object({
+              userId: z.string().describe('ID of the current user'),
+              type1: z
+          .enum(['Normal', 'Unknown'])
+          .describe('Type of the item').optional().describe('Type 1 of the item')
+            })
+            .merge({
+              z.object({
+                type2: z
+          .enum(['Normal', 'Unknown'])
+          .describe('Type of the item').optional().describe('Type 2 of the item')
+              })
+            })
+            .describe('Options to find many items'),
+        })"
+`;

--- a/packages/nestjs-trpc/lib/generators/__tests__/generator.module.spec.ts
+++ b/packages/nestjs-trpc/lib/generators/__tests__/generator.module.spec.ts
@@ -1,0 +1,23 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GeneratorModule } from '../generator.module';
+
+describe('GeneratorModule', () => {
+  let generatorModule: GeneratorModule;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        GeneratorModule.forRoot({
+            rootModuleFilePath: '',
+            tsConfigFilePath: './tsconfig.json',
+        }),
+      ],
+    }).compile();
+
+    generatorModule = module.get<GeneratorModule>(GeneratorModule);
+  });
+
+  it('should be defined', () => {
+    expect(generatorModule).toBeDefined();
+  });
+});

--- a/packages/nestjs-trpc/lib/generators/__tests__/procedure.generator.spec.ts
+++ b/packages/nestjs-trpc/lib/generators/__tests__/procedure.generator.spec.ts
@@ -107,5 +107,36 @@ describe('ProcedureGenerator', () => {
       const result = procedureGenerator.flattenZodSchema(node, sourceFile, project, node.getText());
       expect(result).toMatchSnapshot();
     });
+
+    it('should flatten enum to literal value', () => {
+      project.createSourceFile(
+        "types.ts",
+        `
+        export enum TypeEnum { Normal = 'Normal', Unknown = 'Unknown' };
+        `,
+        { overwrite: true }
+      );
+      const sourceFile: SourceFile = project.createSourceFile(
+        "test.ts",
+        `
+        import { z } from 'zod';
+        import { TypeEnum } from './types';
+
+        const FindManyInput = z.object({
+          options: z
+            .object({
+              userId: z.string().describe('ID of the current user'),
+              type: z.literal(TypeEnum.Normal).describe('Type of the item')
+            })
+            .describe('Options to find many items'),
+        });
+        `,
+        { overwrite: true }
+      );
+
+      const node = sourceFile.getDescendantsOfKind(SyntaxKind.Identifier).find((identifier) => identifier.getText() === "FindManyInput") as Identifier;
+      const result = procedureGenerator.flattenZodSchema(node, sourceFile, project, node.getText());
+      expect(result).toMatchSnapshot();
+    });
   });
 });

--- a/packages/nestjs-trpc/lib/generators/generator.interface.ts
+++ b/packages/nestjs-trpc/lib/generators/generator.interface.ts
@@ -6,4 +6,5 @@ export interface GeneratorModuleOptions {
   context?: Class<TRPCContext>;
   outputDirPath?: string;
   schemaFileImports?: Array<SchemaImports>;
+  tsConfigFilePath?: string;
 }

--- a/packages/nestjs-trpc/lib/generators/generator.module.ts
+++ b/packages/nestjs-trpc/lib/generators/generator.module.ts
@@ -58,7 +58,10 @@ export class GeneratorModule implements OnModuleInit {
       checkJs: true,
       esModuleInterop: true,
     };
-    const project = new Project({ compilerOptions: defaultCompilerOptions });
+    const project = new Project({
+      compilerOptions: defaultCompilerOptions,
+      tsConfigFilePath: options.tsConfigFilePath,
+    });
 
     const appRouterSourceFile = project.createSourceFile(
       path.resolve(options.outputDirPath ?? './', 'server.ts'),

--- a/packages/nestjs-trpc/lib/generators/procedure.generator.ts
+++ b/packages/nestjs-trpc/lib/generators/procedure.generator.ts
@@ -140,6 +140,16 @@ export class ProcedureGenerator {
           this.flattenZodSchema(arg, sourceFile, project, argText),
         );
       }
+
+      for (const child of expression.getChildren()) {
+        if (Node.isCallExpression(child)) {
+          const childText = child.getText();
+          schema = schema.replace(
+            childText,
+            this.flattenZodSchema(child, sourceFile, project, childText),
+          );
+        }
+      }
     } else if (Node.isPropertyAccessExpression(node)) {
       schema = this.flattenZodSchema(
         node.getExpression(),

--- a/packages/nestjs-trpc/lib/interfaces/module-options.interface.ts
+++ b/packages/nestjs-trpc/lib/interfaces/module-options.interface.ts
@@ -20,6 +20,11 @@ export interface TRPCModuleOptions {
   autoSchemaFile?: string;
 
   /**
+   * Path to project tsconfig.
+   */
+  tsConfigFilePath?: string;
+
+  /**
    * Specifies additional imports for the schema file. This array can include functions, objects, or Zod schemas.
    * While `nestjs-trpc` typically handles imports automatically, this option allows manual inclusion of imports for exceptional cases.
    * Use this property only when automatic import resolution is insufficient.

--- a/packages/nestjs-trpc/lib/trpc.module.ts
+++ b/packages/nestjs-trpc/lib/trpc.module.ts
@@ -54,6 +54,7 @@ export class TRPCModule implements OnModuleInit {
       imports.push(
         GeneratorModule.forRoot({
           outputDirPath: options.autoSchemaFile,
+          tsConfigFilePath: options.tsConfigFilePath,
           rootModuleFilePath: callerFilePath,
           schemaFileImports: options.schemaFileImports,
           context: options.context,


### PR DESCRIPTION
There are 3 fixes in this PR:

### Fix 1: Flatten chained function calls.

An example: 

```typescript
import { z } from 'zod';

const TypeEnum = z
  .enum(['Normal', 'Unknown'])
  .describe('Type of the item');

const FindManyInput = z.object({
  options: z
    .object({
      userId: z.string().describe('ID of the current user'),
      type1: TypeEnum.optional().describe('Type 1 of the item')
    })
    .merge({
      z.object({
        type2: TypeEnum.optional().describe('Type 2 of the item')
      })
    })
    .describe('Options to find many items'),
});
```

Before the fix, references to `TypeEnum` are not flattened in `FindManyInput` because it's referenced as parameters of the `object()` and `merge()` calls instead of the last `describe()` call.

After the fix, The `TypeEnum` schema is properly flattened in all places that reference it.

### Fix 2: add `tsConfigFilePath` to module config.

See issue: https://github.com/KevinEdry/nestjs-trpc/issues/18

### Fix 3: Flatten enum name to literal values.

An example:

```typescript
// types.ts
export enum TypeEnum { Normal = 'Normal', Unknown = 'Unknown' };
```

```typescript
// test.ts
import { z } from 'zod';
import { TypeEnum } from './types';

const FindManyInput = z.object({
  options: z
    .object({
      userId: z.string().describe('ID of the current user'),
      type: z.literal(TypeEnum.Normal).describe('Type of the item')
    })
    .describe('Options to find many items'),
});
```

Before the fix, it generates: `type: z.literal(export enum TypeEnum { Normal = 'Normal', Unknown = 'Unknown' }).describe('Type of the item')`

After the fix, it generates: `type: z.literal('Normal').describe('Type of the item')`
