### PR TITLE
fix(packages/nestjs-trpc): support `superjson` transformer

### DIFF
--- a/docs/pages/docs/integrations.mdx
+++ b/docs/pages/docs/integrations.mdx
@@ -6,6 +6,56 @@ import { Callout, Steps, Tabs } from 'nextra-theme-docs';
 
 # Integrations
 
+### Data Transformers
+You are able to serialize the response data & input args. Right now the only supported transformer is `superjson`.
+
+You need to use `superjson` version `1.13.3` because version `^2.0.0` doesn't support commonjs.
+
+To use `superjson`, you can install it using your preferred package manager:
+
+<Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
+  <Tabs.Tab>
+    ```bash copy
+    npm install superjson@1.13.3
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```bash copy
+    pnpm add superjson@1.13.3
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```bash copy
+    yarn add superjson@1.13.3
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```bash copy
+    bun install superjson@1.13.3
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+And then you can use it in your `TRPCModule` options:
+
+```typescript filename="app.module.ts" copy
+import { Module } from '@nestjs/common';
+import { TRPCModule } from 'nestjs-trpc';
+import { superjson } from 'superjson';
+
+@Module({
+  imports: [
+    TRPCModule.forRoot({
+      autoSchemaFile: './src/@generated',
+      transformer: superjson,
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+
+
 ### Accessing the AppRouter
 In some circumstances ,for example end-to-end tests or integrating with other `trpc` plugins, you may want to get a reference to the generated appRouter object. In end-to-end tests, you can then run queries using the appRouter object directly without using any HTTP listeners.
 

--- a/packages/nestjs-trpc/lib/generators/generator.interface.ts
+++ b/packages/nestjs-trpc/lib/generators/generator.interface.ts
@@ -1,9 +1,11 @@
 import type { SchemaImports, TRPCContext } from '../interfaces';
 import type { Class } from 'type-fest';
+import type { RootConfigTypes } from '@trpc/server/dist/core/internals/config';
 
 export interface GeneratorModuleOptions {
   rootModuleFilePath: string;
   context?: Class<TRPCContext>;
   outputDirPath?: string;
   schemaFileImports?: Array<SchemaImports>;
+  transformer?: RootConfigTypes['transformer'];
 }

--- a/packages/nestjs-trpc/lib/generators/generator.module.ts
+++ b/packages/nestjs-trpc/lib/generators/generator.module.ts
@@ -84,7 +84,10 @@ export class GeneratorModule implements OnModuleInit {
   }
 
   async onModuleInit() {
-    await this.trpcGenerator.generateSchemaFile(this.options.schemaFileImports);
+    await this.trpcGenerator.generateSchemaFile(
+      this.options.schemaFileImports,
+      this.options.transformer,
+    );
     await this.trpcGenerator.generateHelpersFile(this.options.context);
   }
 }

--- a/packages/nestjs-trpc/lib/generators/static.generator.ts
+++ b/packages/nestjs-trpc/lib/generators/static.generator.ts
@@ -8,10 +8,14 @@ import {
 import { Injectable } from '@nestjs/common';
 import { SourceFileImportsMap } from '../interfaces/generator.interface';
 import * as path from 'node:path';
+import type { RootConfigTypes } from '@trpc/server/dist/core/internals/config';
 
 @Injectable()
 export class StaticGenerator {
-  public generateStaticDeclaration(sourceFile: SourceFile): void {
+  public generateStaticDeclaration(
+    sourceFile: SourceFile,
+    transformer?: RootConfigTypes['transformer'],
+  ): void {
     sourceFile.addImportDeclaration({
       kind: StructureKind.ImportDeclaration,
       moduleSpecifier: '@trpc/server',
@@ -23,10 +27,24 @@ export class StaticGenerator {
       namedImports: ['z'],
     });
 
+    if (transformer != null)
+      sourceFile.addImportDeclaration({
+        kind: StructureKind.ImportDeclaration,
+        moduleSpecifier: 'superjson',
+        defaultImport: 'superjson',
+      });
+
     sourceFile.addVariableStatements([
       {
         declarationKind: VariableDeclarationKind.Const,
-        declarations: [{ name: 't', initializer: 'initTRPC.create()' }],
+        declarations: [
+          {
+            name: 't',
+            initializer: transformer
+              ? 'initTRPC.create({ transformer: superjson })'
+              : 'initTRPC.create()',
+          },
+        ],
       },
       {
         declarationKind: VariableDeclarationKind.Const,

--- a/packages/nestjs-trpc/lib/generators/trpc.generator.ts
+++ b/packages/nestjs-trpc/lib/generators/trpc.generator.ts
@@ -24,6 +24,7 @@ import {
   TYPESCRIPT_PROJECT,
 } from './generator.constants';
 import * as process from 'node:process';
+import type { RootConfigTypes } from '@trpc/server/dist/core/internals/config';
 
 @Injectable()
 export class TRPCGenerator implements OnModuleInit {
@@ -73,6 +74,7 @@ export class TRPCGenerator implements OnModuleInit {
 
   public async generateSchemaFile(
     schemaImports?: Array<SchemaImports> | undefined,
+    transformer?: RootConfigTypes['transformer'],
   ): Promise<void> {
     try {
       const routers = this.routerFactory.getRouters();
@@ -87,7 +89,10 @@ export class TRPCGenerator implements OnModuleInit {
         return { name, path, alias, instance: { ...route }, procedures };
       });
 
-      this.staticGenerator.generateStaticDeclaration(this.appRouterSourceFile);
+      this.staticGenerator.generateStaticDeclaration(
+        this.appRouterSourceFile,
+        transformer,
+      );
 
       if (schemaImports != null && schemaImports.length > 0) {
         const schemaImportNames: Array<string> = schemaImports.map(

--- a/packages/nestjs-trpc/lib/interfaces/module-options.interface.ts
+++ b/packages/nestjs-trpc/lib/interfaces/module-options.interface.ts
@@ -1,4 +1,4 @@
-import { RootConfigTypes } from '@trpc/server/dist/core/internals/config';
+import type { RootConfigTypes } from '@trpc/server/dist/core/internals/config';
 import { ErrorFormatter } from '@trpc/server/dist/error/formatter';
 import { TRPCErrorShape } from '@trpc/server/dist/rpc';
 import { TRPCContext } from './context.interface';


### PR DESCRIPTION
This PR aims to fix support for `superjson` transformer

How to test it?

Go to any nestjs example, install `superjson@1.13.3` and apply it on `TRPCModule`.