### PR TITLE
style: mention source maps if they are missing

### DIFF
--- a/packages/nestjs-trpc/lib/generators/router.generator.ts
+++ b/packages/nestjs-trpc/lib/generators/router.generator.ts
@@ -52,7 +52,9 @@ export class RouterGenerator {
     const classDeclaration = sourceFile.getClass(routerName);
 
     if (!classDeclaration) {
-      throw new Error(`Could not find router ${routerName} class declaration.`);
+      throw new Error(
+        `Could not find router ${routerName} class declaration. Did you set compilerOptions.sourceMap to true in tsconfig.json?`,
+      );
     }
 
     const methodDeclaration = classDeclaration.getMethod(procedure.name);


### PR DESCRIPTION
When sourceMap is set to false, the router generator fails to find the
TypeScript class declaration for the router and fails. This requirement
is mentioned in the documentation, but debugging is faster if it is
also mentioned at the time the source maps are actually needed.
