### PR TITLE
ci(nestjs-trpc): replace deprecated macos-13 runner with macos-14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { target: x86_64-apple-darwin, os: macos-13 }
+          - { target: x86_64-apple-darwin, os: macos-14 }
           - { target: aarch64-apple-darwin, os: macos-14 }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
           - { target: aarch64-unknown-linux-gnu, os: ubuntu-latest }


### PR DESCRIPTION
## Summary

Replace deprecated `macos-13` runner with `macos-14` for the x86_64 macOS CLI build. Rust cross-compiles between macOS architectures natively, so the ARM runner handles both targets.

## Changes

- Update `x86_64-apple-darwin` matrix entry from `macos-13` to `macos-14` in `.github/workflows/release.yml`