### PR TITLE
fix(nestjs-trpc): replace cross with cargo-zigbuild for linux arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,9 @@ jobs:
           target: ${{ matrix.target }}
           cache-workspaces: packages/nestjs-trpc/cli -> target
 
-      - name: Install cross (Linux ARM64)
+      - name: Install cargo-zigbuild (Linux ARM64)
         if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        run: pip3 install ziglang && cargo install cargo-zigbuild
 
       - name: Build CLI
         shell: bash

--- a/scripts/build-cli.sh
+++ b/scripts/build-cli.sh
@@ -61,18 +61,22 @@ if command -v rustc &>/dev/null; then
 fi
 
 BUILD_CMD="cargo"
+BUILD_SUBCMD="build"
 if [[ -n "$HOST_TARGET" && "$TARGET" != "$HOST_TARGET" ]]; then
-  if command -v cross &>/dev/null; then
+  if command -v cargo-zigbuild &>/dev/null; then
+    BUILD_SUBCMD="zigbuild"
+    echo "Cross-compiling with cargo-zigbuild: host=$HOST_TARGET, target=$TARGET"
+  elif command -v cross &>/dev/null; then
     BUILD_CMD="cross"
-    echo "Cross-compiling: host=$HOST_TARGET, target=$TARGET"
+    echo "Cross-compiling with cross: host=$HOST_TARGET, target=$TARGET"
   else
-    echo "Target $TARGET differs from host $HOST_TARGET but 'cross' is not installed."
+    echo "Target $TARGET differs from host $HOST_TARGET but neither 'cargo-zigbuild' nor 'cross' is installed."
     echo "Falling back to cargo (make sure the target toolchain is installed)."
   fi
 fi
 
-echo "Building CLI for $TARGET using $BUILD_CMD..."
-(cd "$CLI_DIR" && $BUILD_CMD build --release --target "$TARGET")
+echo "Building CLI for $TARGET..."
+(cd "$CLI_DIR" && $BUILD_CMD $BUILD_SUBCMD --release --target "$TARGET")
 
 # Place binary in native/{target}/
 DEST_DIR="$NATIVE_DIR/$TARGET"


### PR DESCRIPTION
## Summary

The `cross` Docker image has a glibc too old for the current ubuntu-latest runner, causing Linux ARM64 builds to fail. Switch to `cargo-zigbuild` which cross-compiles using Zig as a linker — no Docker needed.

## Changes

- Replace `cargo install cross` with `pip3 install ziglang && cargo install cargo-zigbuild` in release workflow
- Update `build-cli.sh` to prefer `cargo-zigbuild` over `cross` for cross-compilation