### PR TITLE
fix(nestjs-trpc): preserve target subdirectory in artifact upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: cli-${{ matrix.target }}
-          path: packages/nestjs-trpc/native/${{ matrix.target }}/
+          path: packages/nestjs-trpc/native/
           retention-days: 1
 
   publish:


### PR DESCRIPTION
## Summary

Fix binary verification failure in publish job. The upload path `native/{target}/` strips the subdirectory, so `merge-multiple` dumps all binaries flat. Uploading from `native/` preserves the `{target}/` structure.

## Changes

- Change artifact upload path from `packages/nestjs-trpc/native/${{ matrix.target }}/` to `packages/nestjs-trpc/native/` in `.github/workflows/release.yml`