### PR TITLE
fix(nestjs-trpc): use npm config token env var for bun publish auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
         working-directory: packages/nestjs-trpc
         run: bun publish --access public
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish to npm (dry run)
         if: ${{ github.event_name != 'push' && inputs.dry_run }}


### PR DESCRIPTION
## Summary

`bun publish` reads `NPM_CONFIG_TOKEN`, not `NODE_AUTH_TOKEN` or `NPM_TOKEN`. Rename the env var so bun can authenticate with the npm registry.

## Changes

- Change env var from `NPM_TOKEN` to `NPM_CONFIG_TOKEN` in the publish step