### PR TITLE
feat(nestjs-trpc): add procedure meta support

### DIFF
--- a/docs/pages/docs/middlewares.mdx
+++ b/docs/pages/docs/middlewares.mdx
@@ -200,5 +200,77 @@ export interface AuthMiddlewareContext extends Context {
   </Tabs.Tab>
 </Tabs>
 
+#### Procedure Metadata
+
+Procedures can define a `meta` object that middlewares can read at runtime. This is the tRPC-idiomatic way to implement authorization and other cross-cutting concerns — similar to how NestJS guards use `@SetMetadata()` and `Reflector`.
+
+##### Defining Meta
+
+Pass a `meta` object to the `@Query()` or `@Mutation()` decorator:
+
+```typescript filename="admin.router.ts" copy
+import { Router, Query, Mutation, UseMiddlewares, Input } from 'nestjs-trpc';
+import { z } from 'zod';
+
+@Router({ alias: 'admin' })
+@UseMiddlewares(RolesMiddleware)
+export class AdminRouter {
+  @Query({
+    input: z.object({ userId: z.string() }),
+    meta: { roles: ['admin'] },
+  })
+  async getUser(@Input('userId') userId: string) {
+    return this.userService.getUser(userId);
+  }
+
+  @Mutation({
+    input: z.object({ userId: z.string() }),
+    meta: { roles: ['admin', 'moderator'] },
+  })
+  async deleteUser(@Input('userId') userId: string) {
+    return this.userService.deleteUser(userId);
+  }
+}
+```
+
+##### Reading Meta in Middleware
+
+The `TRPCMiddleware` interface accepts a generic type parameter for `meta`, and `MiddlewareOptions` accepts generics for both context and meta — giving you full type safety without assertions:
+
+```typescript filename="roles.middleware.ts" copy
+import {
+  MiddlewareOptions,
+  MiddlewareResponse,
+  TRPCMiddleware,
+} from 'nestjs-trpc';
+import { Injectable } from '@nestjs/common';
+import { TRPCError } from '@trpc/server';
+import type { AuthMiddlewareContext } from 'nestjs-trpc/types';
+
+interface RolesMeta {
+  roles: string[];
+}
+
+@Injectable()
+export class RolesMiddleware implements TRPCMiddleware<RolesMeta> {
+  async use(opts: MiddlewareOptions<AuthMiddlewareContext, RolesMeta>): Promise<MiddlewareResponse> {
+    const { meta, ctx, next } = opts;
+
+    if (!meta.roles.includes(ctx.auth.userId)) {
+      throw new TRPCError({
+        message: 'Insufficient permissions.',
+        code: 'FORBIDDEN',
+      });
+    }
+
+    return next();
+  }
+}
+```
+
+<Callout>
+  The `TRPCMiddleware<TMeta>` generic defaults to `unknown`, so existing middlewares that don't use meta continue to work without changes.
+</Callout>
+
 #### Dependency injection
 UseMiddlewares fully supports Dependency Injection. Just as with NestJS middlewares and guards, they are able to inject dependencies that are available within the same module. As usual, this is done through the `constructor`.

--- a/docs/pages/docs/routers.mdx
+++ b/docs/pages/docs/routers.mdx
@@ -99,21 +99,23 @@ This can be done by using the right decorator, here is a list of the available p
 <br/>
 <Table columns={["Decorator", "Output"]}>
   <Table.Row>
-    <Table.Cell>`@Query({ input?: ZodSchema, output?: ZodSchema })`</Table.Cell>
+    <Table.Cell>`@Query({ input?, output?, meta? })`</Table.Cell>
     <Table.Cell>`publicProcedure.query()`</Table.Cell>
   </Table.Row>
   <Table.Row>
-    <Table.Cell>`@Mutation({ input?: ZodSchema, output?: ZodSchema })`</Table.Cell>
+    <Table.Cell>`@Mutation({ input?, output?, meta? })`</Table.Cell>
     <Table.Cell>`publicProcedure.mutation()`</Table.Cell>
   </Table.Row>
   <Table.Row>
-    <Table.Cell>`@Subscription({ input?: ZodSchema, output?: ZodSchema })`</Table.Cell>
+    <Table.Cell>`@Subscription({ input?, output?, meta? })`</Table.Cell>
     <Table.Cell>`publicProcedure.subscription()`</Table.Cell>
   </Table.Row>
 </Table>
 
 tRPC procedures may define validation logic for their input and/or output, and validators are also used to infer the types of inputs and outputs in the client-side.
-We can pass those schemas directly to the decorator as shown above.<br/>For me information on how tRPC procedure validation works, check their <Link href={"https://trpc.io/docs/server/validators"} className="underline" target="_blank">official documentation page</Link>.
+We can pass those schemas directly to the decorator as shown above.<br/>For more information on how tRPC procedure validation works, check their <Link href={"https://trpc.io/docs/server/validators"} className="underline" target="_blank">official documentation page</Link>.
+
+Procedures can also define a `meta` object that can be read by middlewares. This is the tRPC-idiomatic way to implement authorization and other cross-cutting concerns, similar to how NestJS guards use decorator metadata. See the <Link href={"/docs/middlewares#procedure-metadata"} className="underline">Procedure Metadata</Link> section in the Middlewares guide for details.
 
 ##### Middlewares
 By default every route will be assigned the `publicProcedure` base, but it is possible to use custom middlewares instead our router via the `@UseMiddlewares()` decorator.

--- a/docs/public/sitemap-0.xml
+++ b/docs/public/sitemap-0.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://nestjs-trpc.io</loc><lastmod>2024-08-25T22:48:16.380Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestjs-trpc.io/docs</loc><lastmod>2024-08-25T22:48:16.380Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestjs-trpc.io/docs/client</loc><lastmod>2024-08-25T22:48:16.380Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestjs-trpc.io/docs/context</loc><lastmod>2024-08-25T22:48:16.380Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestjs-trpc.io/docs/dependency-injection</loc><lastmod>2024-08-25T22:48:16.380Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestjs-trpc.io/docs/graphql</loc><lastmod>2024-08-25T22:48:16.380Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestjs-trpc.io/docs/middlewares</loc><lastmod>2024-08-25T22:48:16.380Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestjs-trpc.io/docs/nestjs</loc><lastmod>2024-08-25T22:48:16.380Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestjs-trpc.io/docs/routers</loc><lastmod>2024-08-25T22:48:16.380Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestjs-trpc.io/docs/structure</loc><lastmod>2024-08-25T22:48:16.380Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://nestjs-trpc.io/docs/trpc</loc><lastmod>2024-08-25T22:48:16.380Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestjs-trpc.io</loc><lastmod>2026-02-09T05:31:11.215Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestjs-trpc.io/docs</loc><lastmod>2026-02-09T05:31:11.216Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestjs-trpc.io/docs/client</loc><lastmod>2026-02-09T05:31:11.216Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestjs-trpc.io/docs/context</loc><lastmod>2026-02-09T05:31:11.216Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestjs-trpc.io/docs/dependency-injection</loc><lastmod>2026-02-09T05:31:11.216Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestjs-trpc.io/docs/graphql</loc><lastmod>2026-02-09T05:31:11.216Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestjs-trpc.io/docs/integrations</loc><lastmod>2026-02-09T05:31:11.216Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestjs-trpc.io/docs/middlewares</loc><lastmod>2026-02-09T05:31:11.216Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestjs-trpc.io/docs/nestjs</loc><lastmod>2026-02-09T05:31:11.216Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestjs-trpc.io/docs/routers</loc><lastmod>2026-02-09T05:31:11.216Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestjs-trpc.io/docs/structure</loc><lastmod>2026-02-09T05:31:11.216Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://nestjs-trpc.io/docs/trpc</loc><lastmod>2026-02-09T05:31:11.216Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/examples/nestjs-fastify/src/app.module.ts
+++ b/examples/nestjs-fastify/src/app.module.ts
@@ -3,6 +3,7 @@ import { UserRouter } from './user.router';
 import { TRPCModule } from 'nestjs-trpc';
 import { UserService } from './user.service';
 import { ProtectedMiddleware } from './protected.middleware';
+import { RolesMiddleware } from './roles.middleware';
 import { AppContext } from './app.context';
 import { TrpcPanelController } from './trpc-panel.controller';
 import { LoggingMiddleware } from './logging.middleware';
@@ -19,6 +20,7 @@ import { LoggingMiddleware } from './logging.middleware';
     AppContext,
     UserService,
     ProtectedMiddleware,
+    RolesMiddleware,
     LoggingMiddleware,
   ],
 })

--- a/examples/nestjs-fastify/src/roles.middleware.ts
+++ b/examples/nestjs-fastify/src/roles.middleware.ts
@@ -1,0 +1,35 @@
+import {
+  MiddlewareOptions,
+  MiddlewareResponse,
+  TRPCMiddleware,
+} from 'nestjs-trpc';
+import { Injectable } from '@nestjs/common';
+import { TRPCError } from '@trpc/server';
+
+export interface RolesMeta {
+  roles: string[];
+}
+
+interface AuthContext {
+  auth: {
+    user: string;
+  };
+}
+
+@Injectable()
+export class RolesMiddleware implements TRPCMiddleware<RolesMeta> {
+  async use(
+    opts: MiddlewareOptions<AuthContext, RolesMeta>,
+  ): Promise<MiddlewareResponse> {
+    const { meta, ctx, next } = opts;
+
+    if (!meta.roles.includes(ctx.auth.user)) {
+      throw new TRPCError({
+        message: 'Insufficient permissions.',
+        code: 'FORBIDDEN',
+      });
+    }
+
+    return next();
+  }
+}

--- a/examples/nestjs-fastify/src/user.router.ts
+++ b/examples/nestjs-fastify/src/user.router.ts
@@ -2,6 +2,7 @@ import { Inject } from '@nestjs/common';
 import {
   Router,
   Query,
+  Mutation,
   UseMiddlewares,
   Input,
   Ctx,
@@ -10,6 +11,7 @@ import {
 } from 'nestjs-trpc';
 import { UserService } from './user.service';
 import { ProtectedMiddleware } from './protected.middleware';
+import { RolesMiddleware } from './roles.middleware';
 import { z } from 'zod';
 import { TRPCError } from '@trpc/server';
 import { User, userSchema } from './user.schema';
@@ -40,5 +42,14 @@ export class UserRouter {
     }
 
     return user;
+  }
+
+  @Mutation({
+    input: z.object({ userId: z.string() }),
+    meta: { roles: ['admin'] },
+  })
+  @UseMiddlewares(RolesMiddleware)
+  async deleteUser(@Input('userId') userId: string): Promise<string> {
+    return `User ${userId} deleted.`;
   }
 }

--- a/packages/nestjs-trpc/lib/decorators/__tests__/mutation.decorator.spec.ts
+++ b/packages/nestjs-trpc/lib/decorators/__tests__/mutation.decorator.spec.ts
@@ -61,4 +61,29 @@ describe('Mutation Decorator', () => {
     const metadata = Reflect.getMetadata(PROCEDURE_METADATA_KEY, TestClass.prototype.testMethod);
     expect(metadata).toEqual({ output: outputSchema });
   });
+
+  it('should set procedure metadata with meta', () => {
+    const inputSchema: ZodSchema = z.string();
+    const meta = { roles: ['admin'] };
+
+    class TestClass {
+      @Mutation({ input: inputSchema, meta })
+      testMethod() {}
+    }
+
+    const metadata = Reflect.getMetadata(PROCEDURE_METADATA_KEY, TestClass.prototype.testMethod);
+    expect(metadata).toEqual({ input: inputSchema, meta });
+  });
+
+  it('should set procedure metadata with only meta', () => {
+    const meta = { requiresAuth: true };
+
+    class TestClass {
+      @Mutation({ meta })
+      testMethod() {}
+    }
+
+    const metadata = Reflect.getMetadata(PROCEDURE_METADATA_KEY, TestClass.prototype.testMethod);
+    expect(metadata).toEqual({ meta });
+  });
 });

--- a/packages/nestjs-trpc/lib/decorators/__tests__/query.decorator.spec.ts
+++ b/packages/nestjs-trpc/lib/decorators/__tests__/query.decorator.spec.ts
@@ -61,4 +61,29 @@ describe('Query Decorator', () => {
     const metadata = Reflect.getMetadata(PROCEDURE_METADATA_KEY, TestClass.prototype.testMethod);
     expect(metadata).toEqual({ output: outputSchema });
   });
+
+  it('should set procedure metadata with meta', () => {
+    const inputSchema = z.string();
+    const meta = { roles: ['admin', 'editor'] };
+
+    class TestClass {
+      @Query({ input: inputSchema, meta })
+      testMethod() {}
+    }
+
+    const metadata = Reflect.getMetadata(PROCEDURE_METADATA_KEY, TestClass.prototype.testMethod);
+    expect(metadata).toEqual({ input: inputSchema, meta });
+  });
+
+  it('should set procedure metadata with only meta', () => {
+    const meta = { public: true };
+
+    class TestClass {
+      @Query({ meta })
+      testMethod() {}
+    }
+
+    const metadata = Reflect.getMetadata(PROCEDURE_METADATA_KEY, TestClass.prototype.testMethod);
+    expect(metadata).toEqual({ meta });
+  });
 });

--- a/packages/nestjs-trpc/lib/decorators/mutation.decorator.ts
+++ b/packages/nestjs-trpc/lib/decorators/mutation.decorator.ts
@@ -18,7 +18,11 @@ import { ProcedureType } from '../trpc.enum';
  *
  * @publicApi
  */
-export function Mutation(args?: { input?: ZodSchema; output?: ZodSchema }) {
+export function Mutation(args?: {
+  input?: ZodSchema;
+  output?: ZodSchema;
+  meta?: Record<string, unknown>;
+}) {
   return applyDecorators(
     ...[
       SetMetadata(PROCEDURE_TYPE_KEY, ProcedureType.Mutation),

--- a/packages/nestjs-trpc/lib/decorators/query.decorator.ts
+++ b/packages/nestjs-trpc/lib/decorators/query.decorator.ts
@@ -18,7 +18,11 @@ import { ProcedureType } from '../trpc.enum';
  *
  * @publicApi
  */
-export function Query(args?: { input?: ZodSchema; output?: ZodSchema }) {
+export function Query(args?: {
+  input?: ZodSchema;
+  output?: ZodSchema;
+  meta?: Record<string, unknown>;
+}) {
   return applyDecorators(
     ...[
       SetMetadata(PROCEDURE_TYPE_KEY, ProcedureType.Query),

--- a/packages/nestjs-trpc/lib/factories/procedure.factory.ts
+++ b/packages/nestjs-trpc/lib/factories/procedure.factory.ts
@@ -60,6 +60,7 @@ export class ProcedureFactory {
     return {
       input: metadata?.input,
       output: metadata?.output,
+      meta: metadata?.meta,
       middlewares,
       type,
       name: callback.name,
@@ -80,7 +81,8 @@ export class ProcedureFactory {
     const serializedProcedures = Object.create({});
 
     for (const procedure of procedures) {
-      const { input, output, type, middlewares, name, params } = procedure;
+      const { input, output, meta, type, middlewares, name, params } =
+        procedure;
 
       const uniqueMiddlewares = uniqWith(
         [...routerMiddlewares, ...middlewares],
@@ -99,6 +101,7 @@ export class ProcedureFactory {
         name,
         input,
         output,
+        meta,
         type,
         routerInstance,
         params,
@@ -160,13 +163,17 @@ export class ProcedureFactory {
     procedureName: string,
     input: any,
     output: any,
+    meta: Record<string, unknown> | undefined,
     type: string,
     routerInstance: Record<string, (...args: any[]) => any>,
     params: Array<ProcedureParamDecorator> | undefined,
   ): any {
-    const procedureWithInput = input
-      ? procedureInstance.input(input)
+    const procedureWithMeta = meta
+      ? procedureInstance.meta(meta)
       : procedureInstance;
+    const procedureWithInput = input
+      ? procedureWithMeta.input(input)
+      : procedureWithMeta;
     const procedureWithOutput = output
       ? procedureWithInput.output(output)
       : procedureWithInput;

--- a/packages/nestjs-trpc/lib/interfaces/factory.interface.ts
+++ b/packages/nestjs-trpc/lib/interfaces/factory.interface.ts
@@ -43,6 +43,7 @@ export interface ProcedureFactoryMetadata {
   type: TRPCProcedureType;
   input: ZodSchema | undefined;
   output: ZodSchema | undefined;
+  meta: Record<string, unknown> | undefined;
   middlewares: Array<Constructor<TRPCMiddleware> | Class<TRPCMiddleware>>;
   name: string;
   implementation: ProcedureImplementation;

--- a/packages/nestjs-trpc/lib/interfaces/middleware.interface.ts
+++ b/packages/nestjs-trpc/lib/interfaces/middleware.interface.ts
@@ -4,19 +4,22 @@ export type MiddlewareResponse = Promise<
   { ok: true; data: unknown } | { ok: false; error: unknown }
 >;
 
-export type MiddlewareOptions<TContext extends object = object> = {
+export type MiddlewareOptions<
+  TContext extends object = object,
+  TMeta = unknown,
+> = {
   ctx: TContext;
   type: TRPCProcedureType;
   path: string;
   input: unknown;
   getRawInput: () => Promise<unknown>;
-  meta: unknown;
+  meta: TMeta;
   signal: AbortSignal | undefined;
   next: (opts?: { ctx?: Record<string, unknown> }) => MiddlewareResponse;
 };
 
-export interface TRPCMiddleware {
+export interface TRPCMiddleware<TMeta = unknown> {
   use(
-    opts: MiddlewareOptions,
+    opts: MiddlewareOptions<object, TMeta>,
   ): MiddlewareResponse | Promise<MiddlewareResponse>;
 }


### PR DESCRIPTION
## Summary

Adds procedure-level `meta` support, enabling tRPC-idiomatic authorization patterns like role-based access control. Procedures can declare metadata via `@Query({ meta })` and `@Mutation({ meta })`, which middlewares read at runtime through `opts.meta` with full type safety via generics — no type assertions needed.

Closes #70

## Changes

- Add `TMeta` generic to `TRPCMiddleware<TMeta>` and `MiddlewareOptions<TCtx, TMeta>` (defaults to `unknown` for backward compat)
- Add optional `meta` field to `@Query()` and `@Mutation()` decorator args
- Thread `meta` through `ProcedureFactoryMetadata` and call `.meta()` on the tRPC procedure builder
- Add `RolesMiddleware` example in the Fastify example app with a `deleteUser` mutation
- Add "Procedure Metadata" section to middlewares docs with typed authorization example
- Update routers docs procedure table to show `meta` option
- Add 10 new unit tests covering decorator metadata storage, factory extraction, and serialization