### PR TITLE
feat(nestjs-trpc): add custom logger support

### DIFF
--- a/docs/pages/docs/index.mdx
+++ b/docs/pages/docs/index.mdx
@@ -126,7 +126,33 @@ const trpcOptions: TRPCModuleOptions = {
     <Table.Cell>`(opts: { shape, error }) => {}`</Table.Cell>
     <Table.Cell>-</Table.Cell>
   </Table.Row>
+  <Table.Row>
+    <Table.Cell icon>`logger`</Table.Cell>
+    <Table.Cell>`LoggerService`</Table.Cell>
+    <Table.Cell>`ConsoleLogger`</Table.Cell>
+  </Table.Row>
 </Table>
+
+#### Custom Logger
+
+By default, **NestJS tRPC** uses the built-in NestJS `ConsoleLogger`. You can provide your own logger by passing any implementation of the NestJS `LoggerService` interface:
+
+```typescript filename="app.module.ts"
+import { Module } from '@nestjs/common';
+import { TRPCModule } from 'nestjs-trpc';
+import { MyLogger } from './my-logger.service';
+
+@Module({
+  imports: [
+    TRPCModule.forRoot({
+      logger: new MyLogger(),
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+This is useful when replacing the default NestJS logger with a production-grade alternative such as [Pino](https://github.com/iamolegga/nestjs-pino), [Winston](https://github.com/gremo/nest-winston), or any other logger that implements the `LoggerService` interface.
 
 ### Supported Platforms
 

--- a/packages/nestjs-trpc/lib/__tests__/trpc.module.spec.ts
+++ b/packages/nestjs-trpc/lib/__tests__/trpc.module.spec.ts
@@ -1,10 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ConsoleLogger } from '@nestjs/common';
 import { HttpAdapterHost } from '@nestjs/core';
 import { TRPCModule } from '../trpc.module';
 import { TRPCDriver } from '../trpc.driver';
 import { AppRouterHost } from '../app-router.host';
-import { TRPC_MODULE_OPTIONS } from '../trpc.constants';
+import { TRPC_LOGGER, TRPC_MODULE_OPTIONS } from '../trpc.constants';
 
 describe('TRPCModule', () => {
   let trpcModule: TRPCModule;
@@ -23,8 +22,8 @@ describe('TRPCModule', () => {
           useValue: { basePath: '/trpc' },
         },
         {
-          provide: ConsoleLogger,
-          useValue: { setContext: jest.fn(), log: jest.fn() },
+          provide: TRPC_LOGGER,
+          useValue: { log: jest.fn() },
         },
         {
           provide: HttpAdapterHost,

--- a/packages/nestjs-trpc/lib/factories/__tests__/procedure.factory.spec.ts
+++ b/packages/nestjs-trpc/lib/factories/__tests__/procedure.factory.spec.ts
@@ -1,6 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ProcedureFactory } from '../procedure.factory';
-import { ConsoleLogger } from '@nestjs/common';
 import { MetadataScanner, ModuleRef } from '@nestjs/core';
 import { z } from 'zod';
 import { TRPCProcedureBuilder, TRPCError, initTRPC } from '@trpc/server';
@@ -8,6 +7,7 @@ import { ProcedureFactoryMetadata, ProcedureParamDecoratorType } from '../../int
 import { TRPCMiddleware } from '../../interfaces';
 import { Ctx, Input, UseMiddlewares, Options, Query, Mutation } from '../../decorators';
 import { ProcedureType } from '../../trpc.enum';
+import { TRPC_LOGGER } from '../../trpc.constants';
 
 describe('ProcedureFactory', () => {
   let procedureFactory: ProcedureFactory;
@@ -19,7 +19,7 @@ describe('ProcedureFactory', () => {
       providers: [
         ProcedureFactory,
         {
-          provide: ConsoleLogger,
+          provide: TRPC_LOGGER,
           useValue: {
             log: jest.fn(),
           },

--- a/packages/nestjs-trpc/lib/factories/__tests__/router.factory.spec.ts
+++ b/packages/nestjs-trpc/lib/factories/__tests__/router.factory.spec.ts
@@ -1,9 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { RouterFactory } from '../router.factory';
-import { ConsoleLogger } from '@nestjs/common';
 import { ModulesContainer } from '@nestjs/core';
 import { ProcedureFactory } from '../procedure.factory';
-import { ROUTER_METADATA_KEY, MIDDLEWARES_KEY, PROCEDURE_TYPE_KEY, PROCEDURE_METADATA_KEY } from '../../trpc.constants';
+import { ROUTER_METADATA_KEY, MIDDLEWARES_KEY, PROCEDURE_TYPE_KEY, PROCEDURE_METADATA_KEY, TRPC_LOGGER } from '../../trpc.constants';
 import { z } from 'zod';
 import { initTRPC, TRPCError } from '@trpc/server';
 import { TRPCMiddleware } from '../../interfaces';
@@ -21,7 +20,7 @@ describe('RouterFactory', () => {
       providers: [
         RouterFactory,
         {
-          provide: ConsoleLogger,
+          provide: TRPC_LOGGER,
           useValue: {
             log: jest.fn(),
           },

--- a/packages/nestjs-trpc/lib/factories/factory.module.ts
+++ b/packages/nestjs-trpc/lib/factories/factory.module.ts
@@ -4,12 +4,21 @@ import { TRPCFactory } from './trpc.factory';
 import { RouterFactory } from './router.factory';
 import { ProcedureFactory } from './procedure.factory';
 import { MiddlewareFactory } from './middleware.factory';
+import { TRPC_LOGGER } from '../trpc.constants';
+import { LOGGER_CONTEXT } from '../trpc.constants';
 
 @Module({
   imports: [],
   providers: [
     // NestJS Providers
-    ConsoleLogger,
+    {
+      provide: TRPC_LOGGER,
+      useFactory: () => {
+        const logger = new ConsoleLogger();
+        logger.setContext(LOGGER_CONTEXT);
+        return logger;
+      },
+    },
     MetadataScanner,
 
     // Local Providers

--- a/packages/nestjs-trpc/lib/factories/procedure.factory.ts
+++ b/packages/nestjs-trpc/lib/factories/procedure.factory.ts
@@ -1,10 +1,12 @@
-import { ConsoleLogger, Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import type { LoggerService } from '@nestjs/common';
 import { MetadataScanner, ModuleRef } from '@nestjs/core';
 import {
   MIDDLEWARES_KEY,
   PROCEDURE_METADATA_KEY,
   PROCEDURE_PARAM_METADATA_KEY,
   PROCEDURE_TYPE_KEY,
+  TRPC_LOGGER,
 } from '../trpc.constants';
 import {
   ProcedureFactoryMetadata,
@@ -21,7 +23,7 @@ import { uniqWith, isEqual } from 'lodash';
 @Injectable()
 export class ProcedureFactory {
   constructor(
-    private readonly consoleLogger: ConsoleLogger,
+    @Inject(TRPC_LOGGER) private readonly logger: LoggerService,
     @Inject(MetadataScanner) private readonly metadataScanner: MetadataScanner,
     @Inject(ModuleRef) private readonly moduleRef: ModuleRef,
   ) {}
@@ -107,7 +109,7 @@ export class ProcedureFactory {
         params,
       );
 
-      this.consoleLogger.log(
+      this.logger.log(
         `Mapped {${type}, ${camelCasedRouterName}.${name}} route.`,
         'Router Factory',
       );

--- a/packages/nestjs-trpc/lib/factories/router.factory.ts
+++ b/packages/nestjs-trpc/lib/factories/router.factory.ts
@@ -1,8 +1,13 @@
-import { ConsoleLogger, Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import type { LoggerService } from '@nestjs/common';
 import { ModulesContainer } from '@nestjs/core';
 import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
 import { camelCase } from 'lodash';
-import { MIDDLEWARES_KEY, ROUTER_METADATA_KEY } from '../trpc.constants';
+import {
+  MIDDLEWARES_KEY,
+  ROUTER_METADATA_KEY,
+  TRPC_LOGGER,
+} from '../trpc.constants';
 import {
   RouterInstance,
   TRPCPublicProcedure,
@@ -15,7 +20,7 @@ import { Class, Constructor } from 'type-fest';
 @Injectable()
 export class RouterFactory {
   constructor(
-    private readonly consoleLogger: ConsoleLogger,
+    @Inject(TRPC_LOGGER) private readonly logger: LoggerService,
     @Inject(ModulesContainer)
     private readonly modulesContainer: ModulesContainer,
     private readonly procedureFactory: ProcedureFactory,
@@ -84,7 +89,7 @@ export class RouterFactory {
         prototype,
       );
 
-      this.consoleLogger.log(
+      this.logger.log(
         `Router ${name} as ${camelCasedRouterName}.`,
         'Router Factory',
       );

--- a/packages/nestjs-trpc/lib/interfaces/module-options.interface.ts
+++ b/packages/nestjs-trpc/lib/interfaces/module-options.interface.ts
@@ -4,6 +4,7 @@ import type {
   DataTransformer,
   CombinedDataTransformer,
 } from '@trpc/server';
+import type { LoggerService } from '@nestjs/common';
 import { TRPCContext } from './context.interface';
 import type { Class } from 'type-fest';
 
@@ -28,4 +29,11 @@ export interface TRPCModuleOptions {
    * @link https://trpc.io/docs/data-transformers
    */
   transformer?: DataTransformer | CombinedDataTransformer;
+
+  /**
+   * Custom logger instance to use instead of the default NestJS ConsoleLogger.
+   * Must implement the NestJS LoggerService interface.
+   * @link https://docs.nestjs.com/techniques/logger
+   */
+  logger?: LoggerService;
 }

--- a/packages/nestjs-trpc/lib/trpc.constants.ts
+++ b/packages/nestjs-trpc/lib/trpc.constants.ts
@@ -16,3 +16,4 @@ export const MIDDLEWARES_KEY = Symbol('trpc:middlewares_key');
 
 // Logging Constants
 export const LOGGER_CONTEXT = 'TRPC';
+export const TRPC_LOGGER = 'TrpcLogger';

--- a/packages/nestjs-trpc/lib/trpc.driver.ts
+++ b/packages/nestjs-trpc/lib/trpc.driver.ts
@@ -1,4 +1,5 @@
-import { ConsoleLogger, Inject, Injectable, Type } from '@nestjs/common';
+import { Inject, Injectable, Type } from '@nestjs/common';
+import type { LoggerService } from '@nestjs/common';
 import { HttpAdapterHost, ModuleRef } from '@nestjs/core';
 import type { Application as ExpressApplication } from 'express';
 import type { FastifyInstance as FastifyApplication } from 'fastify';
@@ -7,6 +8,7 @@ import { AnyRouter, initTRPC } from '@trpc/server';
 import { TRPCFactory } from './factories/trpc.factory';
 import { AppRouterHost } from './app-router.host';
 import { ExpressDriver, FastifyDriver } from './drivers';
+import { TRPC_LOGGER } from './trpc.constants';
 
 function isExpressApplication(app: any): app is ExpressApplication {
   return (
@@ -37,7 +39,7 @@ export class TRPCDriver<
     @Inject(HttpAdapterHost)
     protected readonly httpAdapterHost: HttpAdapterHost,
     protected readonly trpcFactory: TRPCFactory,
-    protected readonly consoleLogger: ConsoleLogger,
+    @Inject(TRPC_LOGGER) protected readonly logger: LoggerService,
     protected readonly appRouterHost: AppRouterHost,
     protected readonly expressDriver: ExpressDriver,
     protected readonly fastifyDriver: FastifyDriver,


### PR DESCRIPTION
## Summary

Add support for custom loggers in `TRPCModule.forRoot()` options, allowing users to replace the default NestJS `ConsoleLogger` with any `LoggerService` implementation (e.g., Pino, Winston). Closes #67.

## Changes

- Add `logger?: LoggerService` option to `TRPCModuleOptions` interface
- Introduce `TRPC_LOGGER` injection token to decouple from concrete `ConsoleLogger`
- Replace all `ConsoleLogger` injections with `LoggerService` via token in `TRPCModule`, `TRPCDriver`, `RouterFactory`, and `ProcedureFactory`
- Factory provider in `forRoot()` uses the custom logger if provided, falls back to `ConsoleLogger` with `TRPC` context
- Update documentation with `logger` option in Module Options table and usage example
- Update all test mocks to use the new `TRPC_LOGGER` token