### PR TITLE
fix(nestjs-trpc): use --latest flag for release notes generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
         id: changelog
         run: |
           git-cliff --tag "v${{ steps.version.outputs.version }}" -o CHANGELOG.md
-          git-cliff --unreleased --tag "v${{ steps.version.outputs.version }}" > RELEASE_NOTES.md
+          git-cliff --latest > RELEASE_NOTES.md
 
           {
             echo 'changelog<<EOF'


### PR DESCRIPTION
## Summary

Fix empty release notes when creating GitHub releases from tags. The `git-cliff` command used `--unreleased --tag` which finds zero commits because the tag already exists when the workflow runs.

## Changes

- Replace `git-cliff --unreleased --tag ...` with `git-cliff --latest` in `.github/workflows/release.yml`