### PR TITLE
fix(nestjs-trpc): commit changelog back to main during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,3 +169,14 @@ jobs:
             release-assets/nestjs-trpc-windows-x64.exe
             release-assets/checksums.txt
 
+      - name: Commit changelog to main
+        if: ${{ github.event_name == 'push' || !inputs.dry_run }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout main
+          git add CHANGELOG.md
+          git diff --cached --quiet && exit 0
+          git commit -m "chore(release): update changelog for v${{ steps.version.outputs.version }}"
+          git push origin main
+


### PR DESCRIPTION
## Summary

The release workflow generates `CHANGELOG.md` via `git-cliff` but never commits it back to the repository, so it's lost after each CI run. This adds a step to commit and push the updated changelog to `main` after the GitHub release is created.

## Changes

- Add "Commit changelog to main" step at the end of the publish job in `.github/workflows/release.yml`