### PR TITLE
fix(nestjs-trpc): fix release notes versioning and commit changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
         id: changelog
         run: |
           git-cliff --tag "v${{ steps.version.outputs.version }}" -o CHANGELOG.md
-          git-cliff --latest > RELEASE_NOTES.md
+          git-cliff --latest --tag "v${{ steps.version.outputs.version }}" --strip all > RELEASE_NOTES.md
 
           {
             echo 'changelog<<EOF'
@@ -168,4 +168,15 @@ jobs:
             release-assets/nestjs-trpc-linux-arm64
             release-assets/nestjs-trpc-windows-x64.exe
             release-assets/checksums.txt
+
+      - name: Commit changelog to main
+        if: ${{ github.event_name == 'push' || !inputs.dry_run }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout main
+          git add CHANGELOG.md
+          git diff --cached --quiet && exit 0
+          git commit -m "chore(release): update changelog for v${{ steps.version.outputs.version }}"
+          git push origin main
 


### PR DESCRIPTION
## Summary

Fixes two issues with the release workflow:

1. **Release notes showed "[Unreleased]" instead of version** — `git-cliff --latest` alone doesn't set the `version` template variable. Adding `--tag` explicitly sets it, and `--strip all` removes the changelog header/footer for clean GitHub release bodies.
2. **CHANGELOG.md never committed back to repo** — the workflow generated it on the CI runner but discarded it. Now commits it to `main` after the release is created.

## Changes

- Add `--tag` and `--strip all` flags to the release notes `git-cliff` command in `.github/workflows/release.yml`
- Add "Commit changelog to main" step after GitHub release creation