### PR TITLE
feat(nestjs-trpc): add onError handler with DI support

### DIFF
--- a/docs/pages/docs/_meta.json
+++ b/docs/pages/docs/_meta.json
@@ -25,6 +25,7 @@
   "subscriptions": "Subscriptions",
   "middlewares": "Middlewares",
   "context": "Context",
+  "error-handling": "Error Handling",
   "dependency-injection": "Dependency Injection",
   "client": "Client Usage",
   "integrations": "Integrations",

--- a/docs/pages/docs/error-handling.mdx
+++ b/docs/pages/docs/error-handling.mdx
@@ -1,0 +1,69 @@
+---
+title: "NestJS-tRPC Documentation - Error Handling"
+---
+
+import { Callout, Steps } from 'nextra/components';
+import TrpcIcon from '../../public/icons/trpc.svg';
+import Link from 'next/link';
+
+# Error Handling
+
+The `onError` handler is invoked whenever a tRPC procedure throws an error.
+It is useful for reporting errors to external services, logging, or performing side-effects on failures.
+
+<Callout emoji={<TrpcIcon width={25} height={50} className="m-1"/>}>
+  If you are not sure about how tRPC handles errors, you can dive deeper into those concepts in their <Link href={"https://trpc.io/docs/server/error-handling#handling-errors"} target="blank" className="underline"> official documentation</Link>.
+</Callout>
+
+Setting up an error handler can be done in 3 steps, defining the error handler class, registering it with your module, and passing it to the `onError` option of the TRPCModule.
+
+<Steps>
+  ### Defining an Error Handler
+  To define a new error handler, create a class that implements `TRPCErrorHandler` and its method `onError(){:tsx}`.
+  ```typescript filename="app.error-handler.ts" copy
+  import { Inject, Injectable } from '@nestjs/common';
+  import { OnErrorOptions, TRPCErrorHandler } from 'nestjs-trpc';
+
+  @Injectable()
+  export class AppErrorHandler implements TRPCErrorHandler {
+    constructor(@Inject('LogService') private readonly logService: LogService) {}
+
+    onError(opts: OnErrorOptions): void {
+      this.logService.error(`[${opts.type}] ${opts.path}: ${opts.error.message}`);
+    }
+  }
+  ```
+
+  <Callout>
+  The `OnErrorOptions` type exposes `error`, `type`, `path`, `input`, `ctx`, and `req` properties.
+  The `error` property is a `TRPCError` instance from `@trpc/server`.
+  </Callout>
+
+  ### Error Handler Registration
+  Similar to NestJS providers, we need to register the error handler with Nest so that it can perform the injection.
+  We do this by editing our module file and adding the error handler to the `providers` array of the `@Module(){:tsx}` decorator.
+
+  ### Including in Options
+  Lastly we need to pass the error handler class to the `onError` option in our `TRPCModule` import definition.
+
+  ```typescript {8} filename="app.module.ts" copy
+  import { Module } from '@nestjs/common';
+  import { TRPCModule } from 'nestjs-trpc';
+  import { AppErrorHandler } from 'app.error-handler';
+
+  @Module({
+    imports: [
+      TRPCModule.forRoot({
+        onError: AppErrorHandler,
+      }),
+    ],
+    providers: [AppErrorHandler],
+  })
+  export class AppModule {}
+  ```
+  Now that the error handler is applied, it will be invoked whenever a procedure throws an error.
+</Steps>
+
+### Dependency Injection
+The error handler class fully supports Dependency Injection. Just as with NestJS providers and controllers,
+it is able to inject dependencies that are available within the same module. As usual, this is done through the `constructor`.

--- a/docs/pages/docs/index.mdx
+++ b/docs/pages/docs/index.mdx
@@ -90,10 +90,6 @@ npx nestjs-trpc generate --output ./src/trpc/types.ts
 
 </Steps>
 
-<Callout type="info" emoji={"💡"}>
-  Setting `"sourceMap": true{:typescript}` in your `compilerOptions` within `tsconfig.json` can help with debugging, but is not required for the CLI to work.
-</Callout>
-
 ### Module Options
 
 You can import `TRPCModuleOptions` type from `nestjs-trpc` to safely assert all of the `TRPCModule` option types.
@@ -130,6 +126,11 @@ const trpcOptions: TRPCModuleOptions = {
     <Table.Cell icon>`logger`</Table.Cell>
     <Table.Cell>`LoggerService`</Table.Cell>
     <Table.Cell>`ConsoleLogger`</Table.Cell>
+  </Table.Row>
+  <Table.Row>
+    <Table.Cell icon>`onError`</Table.Cell>
+    <Table.Cell>`TRPCErrorHandler`</Table.Cell>
+    <Table.Cell>-</Table.Cell>
   </Table.Row>
   <Table.Row>
     <Table.Cell icon>`globalMiddlewares`</Table.Cell>

--- a/docs/theme.config.jsx
+++ b/docs/theme.config.jsx
@@ -11,10 +11,10 @@ export default {
     component: <Footer />
   },
   banner: {
-    key: '1.0-release',
+    key: '2.0.0-release',
     text: (
       <a href="https://github.com/KevinEdry/nestjs-trpc/releases" target="_blank">
-        🎉 NestJS tRPC 1.0 is released. Read more →
+        🎉 NestJS tRPC 2.0.0 is released. Read more →
       </a>
     ),
     dismissible: true

--- a/examples/nestjs-fastify/src/app.error-handler.ts
+++ b/examples/nestjs-fastify/src/app.error-handler.ts
@@ -1,0 +1,13 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnErrorOptions, TRPCErrorHandler } from 'nestjs-trpc';
+
+@Injectable()
+export class AppErrorHandler implements TRPCErrorHandler {
+  private readonly logger = new Logger(AppErrorHandler.name);
+
+  onError(opts: OnErrorOptions): void {
+    this.logger.error(
+      `tRPC error on ${opts.path} [${opts.type}]: ${opts.error.message}`,
+    );
+  }
+}

--- a/examples/nestjs-fastify/src/app.module.ts
+++ b/examples/nestjs-fastify/src/app.module.ts
@@ -6,6 +6,7 @@ import { UserService } from './user.service';
 import { ProtectedMiddleware } from './protected.middleware';
 import { RolesMiddleware } from './roles.middleware';
 import { AppContext } from './app.context';
+import { AppErrorHandler } from './app.error-handler';
 import { TrpcPanelController } from './trpc-panel.controller';
 import { LoggingMiddleware } from './logging.middleware';
 
@@ -13,6 +14,7 @@ import { LoggingMiddleware } from './logging.middleware';
   imports: [
     TRPCModule.forRoot({
       context: AppContext,
+      onError: AppErrorHandler,
       globalMiddlewares: [LoggingMiddleware],
     }),
   ],
@@ -21,6 +23,7 @@ import { LoggingMiddleware } from './logging.middleware';
     UserRouter,
     EventRouter,
     AppContext,
+    AppErrorHandler,
     UserService,
     ProtectedMiddleware,
     RolesMiddleware,

--- a/packages/nestjs-trpc/lib/__tests__/trpc.driver.spec.ts
+++ b/packages/nestjs-trpc/lib/__tests__/trpc.driver.spec.ts
@@ -154,4 +154,46 @@ describe('TRPCDriver', () => {
       });
     });
   });
+
+  describe('onError handler', () => {
+    it('should resolve onError instance from moduleRef and pass it to the driver', async () => {
+      class TestErrorHandler {
+        onError = jest.fn();
+      }
+
+      const errorHandlerInstance = new TestErrorHandler();
+      jest.spyOn(moduleRef, 'get').mockReturnValue(errorHandlerInstance);
+
+      const options: TRPCModuleOptions = {
+        onError: TestErrorHandler,
+      };
+
+      await trpcDriver.start(options);
+
+      expect(moduleRef.get).toHaveBeenCalledWith(TestErrorHandler, {
+        strict: false,
+      });
+      expect(mockExpressDriver.start).toHaveBeenCalledWith(
+        options,
+        mockExpressApp,
+        expect.anything(),
+        null,
+        errorHandlerInstance,
+      );
+    });
+
+    it('should pass null when onError is not provided', async () => {
+      const options: TRPCModuleOptions = {};
+
+      await trpcDriver.start(options);
+
+      expect(mockExpressDriver.start).toHaveBeenCalledWith(
+        options,
+        mockExpressApp,
+        expect.anything(),
+        null,
+        null,
+      );
+    });
+  });
 });

--- a/packages/nestjs-trpc/lib/drivers/express.driver.ts
+++ b/packages/nestjs-trpc/lib/drivers/express.driver.ts
@@ -1,6 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import type { Application as ExpressApplication } from 'express';
-import { TRPCContext, TRPCModuleOptions } from '../interfaces';
+import {
+  TRPCContext,
+  TRPCErrorHandler,
+  TRPCModuleOptions,
+} from '../interfaces';
 import type { AnyRouter } from '@trpc/server';
 import * as trpcExpress from '@trpc/server/adapters/express';
 
@@ -13,6 +17,7 @@ export class ExpressDriver<
     app: ExpressApplication,
     appRouter: AnyRouter,
     contextInstance: TRPCContext | null,
+    onErrorInstance: TRPCErrorHandler | null,
   ) {
     app.use(
       options.basePath ?? '/trpc',
@@ -21,6 +26,11 @@ export class ExpressDriver<
         ...(options.context != null && contextInstance != null
           ? {
               createContext: (opts) => contextInstance.create(opts),
+            }
+          : {}),
+        ...(options.onError != null && onErrorInstance != null
+          ? {
+              onError: (opts) => onErrorInstance.onError(opts),
             }
           : {}),
       }),

--- a/packages/nestjs-trpc/lib/drivers/fastify.driver.ts
+++ b/packages/nestjs-trpc/lib/drivers/fastify.driver.ts
@@ -1,6 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import type { FastifyInstance as FastifyApplication } from 'fastify';
-import { ContextOptions, TRPCContext, TRPCModuleOptions } from '../interfaces';
+import {
+  ContextOptions,
+  TRPCContext,
+  TRPCErrorHandler,
+  TRPCModuleOptions,
+} from '../interfaces';
 import type { AnyRouter } from '@trpc/server';
 import * as trpcFastify from '@trpc/server/adapters/fastify';
 
@@ -13,6 +18,7 @@ export class FastifyDriver<
     app: FastifyApplication,
     appRouter: AnyRouter,
     contextInstance: TRPCContext | null,
+    onErrorInstance: TRPCErrorHandler | null,
   ) {
     app.register(trpcFastify.fastifyTRPCPlugin, {
       prefix: options.basePath ?? '/trpc',
@@ -22,6 +28,11 @@ export class FastifyDriver<
           ? {
               createContext: (opts: ContextOptions) =>
                 contextInstance.create(opts),
+            }
+          : {}),
+        ...(options.onError != null && onErrorInstance != null
+          ? {
+              onError: (opts) => onErrorInstance.onError(opts),
             }
           : {}),
       },

--- a/packages/nestjs-trpc/lib/interfaces/error-handler.interface.ts
+++ b/packages/nestjs-trpc/lib/interfaces/error-handler.interface.ts
@@ -1,0 +1,14 @@
+import type { TRPCError, TRPCProcedureType } from '@trpc/server';
+
+export interface OnErrorOptions {
+  error: TRPCError;
+  type: TRPCProcedureType | 'unknown';
+  path: string | undefined;
+  input: unknown;
+  ctx: Record<string, unknown> | undefined;
+  req: unknown;
+}
+
+export interface TRPCErrorHandler {
+  onError(opts: OnErrorOptions): void;
+}

--- a/packages/nestjs-trpc/lib/interfaces/index.ts
+++ b/packages/nestjs-trpc/lib/interfaces/index.ts
@@ -1,4 +1,5 @@
 export * from './context.interface';
+export * from './error-handler.interface';
 export * from './middleware.interface';
 export * from './factory.interface';
 export * from './module-options.interface';

--- a/packages/nestjs-trpc/lib/interfaces/module-options.interface.ts
+++ b/packages/nestjs-trpc/lib/interfaces/module-options.interface.ts
@@ -6,6 +6,7 @@ import type {
 } from '@trpc/server';
 import type { LoggerService } from '@nestjs/common';
 import { TRPCContext } from './context.interface';
+import type { TRPCErrorHandler } from './error-handler.interface';
 import type { TRPCMiddleware } from './middleware.interface';
 import type { Class, Constructor } from 'type-fest';
 
@@ -37,6 +38,13 @@ export interface TRPCModuleOptions {
    * @link https://docs.nestjs.com/techniques/logger
    */
   logger?: LoggerService;
+
+  /**
+   * Injectable error handler invoked whenever a tRPC procedure throws.
+   * Must implement the `TRPCErrorHandler` interface.
+   * @link https://trpc.io/docs/server/error-handling#handling-errors
+   */
+  onError?: Class<TRPCErrorHandler>;
 
   globalMiddlewares?: Array<
     Class<TRPCMiddleware> | Constructor<TRPCMiddleware>


### PR DESCRIPTION
## Summary

Add an injectable `onError` handler to `TRPCModule.forRoot()` that follows the same DI pattern as `TRPCContext`. This allows error reporting, logging, and side-effects on procedure failures using NestJS dependency injection.

Closes #39

## Changes

- Add `TRPCErrorHandler` interface and `OnErrorOptions` type (`lib/interfaces/error-handler.interface.ts`)
- Add `onError` option to `TRPCModuleOptions` accepting a class reference
- Resolve error handler via `ModuleRef` in `TRPCDriver` and pass to platform drivers
- Wire `onError` callback into Express and Fastify adapter options
- Add unit tests for error handler resolution and forwarding (`trpc.driver.spec.ts`)
- Add `AppErrorHandler` example to the Fastify sample app
- Add Error Handling documentation page (`docs/pages/docs/error-handling.mdx`)