### PR TITLE
feat(nestjs-trpc): support zod 4 schemas in decorator input/output

### DIFF
--- a/packages/nestjs-trpc/lib/decorators/__tests__/mutation.decorator.spec.ts
+++ b/packages/nestjs-trpc/lib/decorators/__tests__/mutation.decorator.spec.ts
@@ -2,7 +2,7 @@ import 'reflect-metadata';
 import { Mutation } from '../mutation.decorator';
 import { PROCEDURE_METADATA_KEY, PROCEDURE_TYPE_KEY } from '../../trpc.constants';
 import { ProcedureType } from '../../trpc.enum';
-import { ZodSchema, z } from 'zod';
+import { z } from 'zod';
 
 describe('Mutation Decorator', () => {
   it('should set procedure type metadata', () => {
@@ -16,8 +16,8 @@ describe('Mutation Decorator', () => {
   });
 
   it('should set procedure metadata with input and output schemas', () => {
-    const inputSchema: ZodSchema = z.string();
-    const outputSchema: ZodSchema = z.number();
+    const inputSchema = z.string();
+    const outputSchema = z.number();
 
     class TestClass {
       @Mutation({ input: inputSchema, output: outputSchema })
@@ -39,7 +39,7 @@ describe('Mutation Decorator', () => {
   });
 
   it('should set procedure metadata with only input schema', () => {
-    const inputSchema: ZodSchema = z.string();
+    const inputSchema = z.string();
 
     class TestClass {
       @Mutation({ input: inputSchema })
@@ -51,7 +51,7 @@ describe('Mutation Decorator', () => {
   });
 
   it('should set procedure metadata with only output schema', () => {
-    const outputSchema: ZodSchema = z.number();
+    const outputSchema = z.number();
 
     class TestClass {
       @Mutation({ output: outputSchema })
@@ -63,7 +63,7 @@ describe('Mutation Decorator', () => {
   });
 
   it('should set procedure metadata with meta', () => {
-    const inputSchema: ZodSchema = z.string();
+    const inputSchema = z.string();
     const meta = { roles: ['admin'] };
 
     class TestClass {

--- a/packages/nestjs-trpc/lib/decorators/mutation.decorator.ts
+++ b/packages/nestjs-trpc/lib/decorators/mutation.decorator.ts
@@ -1,7 +1,7 @@
-import { ZodSchema } from 'zod';
 import { applyDecorators, SetMetadata } from '@nestjs/common';
 import { PROCEDURE_METADATA_KEY, PROCEDURE_TYPE_KEY } from '../trpc.constants';
 import { ProcedureType } from '../trpc.enum';
+import type { Parser } from '../interfaces/parser.interface';
 
 /**
  * Decorator that marks a router class method as a TRPC mutation procedure that can receive inbound
@@ -11,16 +11,16 @@ import { ProcedureType } from '../trpc.enum';
  * for example `Mutation /trpc/userRouter.createUser`.
  *
  * @param {object} args configuration object specifying:
- * - `input` - defines a `ZodSchema` validation logic for the input.
- * - `output` - defines a `ZodSchema` validation logic for the output.
+ * - `input` - defines a schema validation logic for the input.
+ * - `output` - defines a schema validation logic for the output.
  *
  * @see [Method Decorators](https://nestjs-trpc.io/docs/routers#procedures)
  *
  * @publicApi
  */
 export function Mutation(args?: {
-  input?: ZodSchema;
-  output?: ZodSchema;
+  input?: Parser;
+  output?: Parser;
   meta?: Record<string, unknown>;
 }) {
   return applyDecorators(

--- a/packages/nestjs-trpc/lib/decorators/query.decorator.ts
+++ b/packages/nestjs-trpc/lib/decorators/query.decorator.ts
@@ -1,7 +1,7 @@
-import { ZodSchema } from 'zod';
 import { applyDecorators, SetMetadata } from '@nestjs/common';
 import { PROCEDURE_METADATA_KEY, PROCEDURE_TYPE_KEY } from '../trpc.constants';
 import { ProcedureType } from '../trpc.enum';
+import type { Parser } from '../interfaces/parser.interface';
 
 /**
  * Decorator that marks a router class method as a TRPC query procedure that can receive inbound
@@ -11,16 +11,16 @@ import { ProcedureType } from '../trpc.enum';
  * for example `Query /trpc/userRouter.getUsers`.
  *
  * @param {object} args configuration object specifying:
- * - `input` - defines a `ZodSchema` validation logic for the input.
- * - `output` - defines a `ZodSchema` validation logic for the output.
+ * - `input` - defines a schema validation logic for the input.
+ * - `output` - defines a schema validation logic for the output.
  *
  * @see [Method Decorators](https://nestjs-trpc.io/docs/routers#procedures)
  *
  * @publicApi
  */
 export function Query(args?: {
-  input?: ZodSchema;
-  output?: ZodSchema;
+  input?: Parser;
+  output?: Parser;
   meta?: Record<string, unknown>;
 }) {
   return applyDecorators(

--- a/packages/nestjs-trpc/lib/decorators/subscription.decorator.ts
+++ b/packages/nestjs-trpc/lib/decorators/subscription.decorator.ts
@@ -1,7 +1,7 @@
-import { ZodSchema } from 'zod';
 import { applyDecorators, SetMetadata } from '@nestjs/common';
 import { PROCEDURE_METADATA_KEY, PROCEDURE_TYPE_KEY } from '../trpc.constants';
 import { ProcedureType } from '../trpc.enum';
+import type { Parser } from '../interfaces/parser.interface';
 
 /**
  * Decorator that marks a router class method as a TRPC subscription procedure that can receive inbound
@@ -11,16 +11,16 @@ import { ProcedureType } from '../trpc.enum';
  * for example `Subscription /trpc/eventRouter.onMessage`.
  *
  * @param {object} args configuration object specifying:
- * - `input` - defines a `ZodSchema` validation logic for the input.
- * - `output` - defines a `ZodSchema` validation logic for the output.
+ * - `input` - defines a schema validation logic for the input.
+ * - `output` - defines a schema validation logic for the output.
  *
  * @see [Method Decorators](https://nestjs-trpc.io/docs/routers#procedures)
  *
  * @publicApi
  */
 export function Subscription(args?: {
-  input?: ZodSchema;
-  output?: ZodSchema;
+  input?: Parser;
+  output?: Parser;
   meta?: Record<string, unknown>;
 }) {
   return applyDecorators(

--- a/packages/nestjs-trpc/lib/interfaces/factory.interface.ts
+++ b/packages/nestjs-trpc/lib/interfaces/factory.interface.ts
@@ -3,10 +3,10 @@ import type {
   AnyRouter,
   TRPCProcedureBuilder,
 } from '@trpc/server';
-import type { ZodSchema, ZodType, ZodTypeDef } from 'zod';
 import type { TRPCMiddleware } from './middleware.interface';
 import type { Class, Constructor } from 'type-fest';
 import type { ProcedureType } from '../trpc.enum';
+import type { Parser } from './parser.interface';
 
 export enum ProcedureParamDecoratorType {
   Options = 'options',
@@ -21,8 +21,8 @@ export type ProcedureImplementation = ({
   input,
   output,
 }: {
-  input?: ZodType<any, ZodTypeDef, any>;
-  output?: ZodType<any, ZodTypeDef, any>;
+  input?: Parser;
+  output?: Parser;
 }) => any;
 
 interface ProcedureParamDecoratorBase {
@@ -41,8 +41,8 @@ export type ProcedureParamDecorator =
 
 export interface ProcedureFactoryMetadata {
   type: ProcedureType;
-  input: ZodSchema | undefined;
-  output: ZodSchema | undefined;
+  input: Parser | undefined;
+  output: Parser | undefined;
   meta: Record<string, unknown> | undefined;
   middlewares: Array<Constructor<TRPCMiddleware> | Class<TRPCMiddleware>>;
   name: string;

--- a/packages/nestjs-trpc/lib/interfaces/index.ts
+++ b/packages/nestjs-trpc/lib/interfaces/index.ts
@@ -3,4 +3,5 @@ export * from './error-handler.interface';
 export * from './middleware.interface';
 export * from './factory.interface';
 export * from './module-options.interface';
+export * from './parser.interface';
 export * from './procedure-options.interface';

--- a/packages/nestjs-trpc/lib/interfaces/parser.interface.ts
+++ b/packages/nestjs-trpc/lib/interfaces/parser.interface.ts
@@ -1,0 +1,83 @@
+/**
+ * Inlined from @trpc/server's parser types to avoid importing from unstable internals.
+ * @see https://github.com/trpc/trpc/blob/main/packages/server/src/unstable-core-do-not-import/parser.ts
+ */
+
+type StandardSchemaV1Result<Output> =
+  | { readonly value: Output; readonly issues?: undefined }
+  | { readonly issues: ReadonlyArray<{ readonly message: string }> };
+
+interface StandardSchemaV1<Input = unknown, Output = Input> {
+  readonly '~standard': {
+    readonly version: 1;
+    readonly vendor: string;
+    readonly validate: (
+      value: unknown,
+    ) =>
+      | StandardSchemaV1Result<Output>
+      | Promise<StandardSchemaV1Result<Output>>;
+    readonly types?:
+      | { readonly input: Input; readonly output: Output }
+      | undefined;
+  };
+}
+
+// Zod / typeschema
+type ParserZodEsque<TInput, TParsedInput> = {
+  _input: TInput;
+  _output: TParsedInput;
+};
+
+type ParserValibotEsque<TInput, TParsedInput> = {
+  schema: {
+    _types?: {
+      input: TInput;
+      output: TParsedInput;
+    };
+  };
+};
+
+type ParserArkTypeEsque<TInput, TParsedInput> = {
+  inferIn: TInput;
+  infer: TParsedInput;
+};
+
+type ParserStandardSchemaEsque<TInput, TParsedInput> = StandardSchemaV1<
+  TInput,
+  TParsedInput
+>;
+
+type ParserMyZodEsque<TInput> = {
+  parse: (input: any) => TInput;
+};
+
+type ParserSuperstructEsque<TInput> = {
+  create: (input: unknown) => TInput;
+};
+
+type ParserCustomValidatorEsque<TInput> = (
+  input: unknown,
+) => Promise<TInput> | TInput;
+
+type ParserYupEsque<TInput> = {
+  validateSync: (input: unknown) => TInput;
+};
+
+type ParserScaleEsque<TInput> = {
+  assert(value: unknown): asserts value is TInput;
+};
+
+type ParserWithoutInput<TInput> =
+  | ParserCustomValidatorEsque<TInput>
+  | ParserMyZodEsque<TInput>
+  | ParserScaleEsque<TInput>
+  | ParserSuperstructEsque<TInput>
+  | ParserYupEsque<TInput>;
+
+type ParserWithInputOutput<TInput, TParsedInput> =
+  | ParserZodEsque<TInput, TParsedInput>
+  | ParserValibotEsque<TInput, TParsedInput>
+  | ParserArkTypeEsque<TInput, TParsedInput>
+  | ParserStandardSchemaEsque<TInput, TParsedInput>;
+
+export type Parser = ParserWithInputOutput<any, any> | ParserWithoutInput<any>;

--- a/packages/nestjs-trpc/package.json
+++ b/packages/nestjs-trpc/package.json
@@ -60,7 +60,7 @@
     "@trpc/server": "^11.0.0",
     "reflect-metadata": "^0.1.13 || ^0.2.0",
     "rxjs": "7.8.1",
-    "zod": "^3.14.0"
+    "zod": "^3.14.0 || ^4.0.0"
   },
   "devDependencies": {
     "@nestjs/common": "10.4.1",


### PR DESCRIPTION
## Summary

Replace the `ZodSchema` type in decorator `input`/`output` signatures with an inlined `Parser` type derived from tRPC's internal parser types. This enables Zod 4 schemas to be passed to `@Query()`, `@Mutation()`, and `@Subscription()` decorators without type errors, while maintaining full backward compatibility with Zod 3.

Per the tRPC team's recommendation, the parser types are inlined rather than imported from `@trpc/server/unstable-core-do-not-import`.

## Changes

- Add `lib/interfaces/parser.interface.ts` with inlined tRPC `Parser` type supporting Zod 3, Zod 4, Valibot, ArkType, Standard Schema, Yup, Superstruct, and custom validators
- Replace `ZodSchema` with `Parser` in `@Query()`, `@Mutation()`, `@Subscription()` decorators
- Replace `ZodSchema`/`ZodType` with `Parser` in `ProcedureFactoryMetadata` and `ProcedureImplementation` interfaces
- Update `zod` peer dependency to `^3.14.0 || ^4.0.0`
- Export `Parser` type from the public API for consumers
- Remove all `zod` imports from library source (only remains in test files)

Closes #100