### PR TITLE
fix(cli): properly handle null exit status from child process

### DIFF
--- a/packages/nestjs-trpc/bin/nestjs-trpc.js
+++ b/packages/nestjs-trpc/bin/nestjs-trpc.js
@@ -67,7 +67,7 @@ try {
     env: process.env,
   });
 } catch (error) {
-  if (error.status !== undefined) {
+  if (error.status != null) {
     process.exit(error.status);
   }
   console.error('Failed to execute nestjs-trpc CLI:', error.message);


### PR DESCRIPTION
Use 'error.status != null' instead of strict undefined check to avoid calling process.exit(null), which incorrectly exits with code 0.