### PR TITLE
feat(docs): add json-ld structured data to docs site

### DIFF
--- a/docs/pages/docs/client.mdx
+++ b/docs/pages/docs/client.mdx
@@ -4,6 +4,27 @@ title: "NestJS-tRPC Documentation - Client Usage"
 
 import { Cards, Card, Callout, Tabs } from 'nextra/components';
 import TrpcIcon from '../../public/icons/trpc.svg';
+import JsonLd from '../../components/JsonLd';
+
+<JsonLd data={{
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'Client Usage',
+  description: 'Set up the tRPC client with auto-generated AppRouter types for end-to-end type-safe API calls from your frontend.',
+  url: 'https://nestjs-trpc.io/docs/client',
+  author: { '@type': 'Person', name: 'Kevin Edry', url: 'https://kevin-edry.com' },
+  publisher: { '@type': 'Organization', name: 'NestJS tRPC', url: 'https://nestjs-trpc.io' },
+  proficiencyLevel: 'Expert',
+}} />
+<JsonLd data={{
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://nestjs-trpc.io' },
+    { '@type': 'ListItem', position: 2, name: 'Docs', item: 'https://nestjs-trpc.io/docs' },
+    { '@type': 'ListItem', position: 3, name: 'Client Usage', item: 'https://nestjs-trpc.io/docs/client' },
+  ],
+}} />
 
 # Client Usage
 

--- a/docs/pages/docs/context.mdx
+++ b/docs/pages/docs/context.mdx
@@ -7,6 +7,27 @@ import Table from "../../components/Table";
 import NestJSIcon from '../../public/icons/nestjs.svg';
 import TrpcIcon from '../../public/icons/trpc.svg';
 import Link from 'next/link';
+import JsonLd from '../../components/JsonLd';
+
+<JsonLd data={{
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'Context',
+  description: 'Set up tRPC context in NestJS — share authentication data, request config, and services across all procedures.',
+  url: 'https://nestjs-trpc.io/docs/context',
+  author: { '@type': 'Person', name: 'Kevin Edry', url: 'https://kevin-edry.com' },
+  publisher: { '@type': 'Organization', name: 'NestJS tRPC', url: 'https://nestjs-trpc.io' },
+  proficiencyLevel: 'Expert',
+}} />
+<JsonLd data={{
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://nestjs-trpc.io' },
+    { '@type': 'ListItem', position: 2, name: 'Docs', item: 'https://nestjs-trpc.io/docs' },
+    { '@type': 'ListItem', position: 3, name: 'Context', item: 'https://nestjs-trpc.io/docs/context' },
+  ],
+}} />
 
 # Context
 Your context holds data that all of your tRPC procedures will have access to, 

--- a/docs/pages/docs/dependency-injection.mdx
+++ b/docs/pages/docs/dependency-injection.mdx
@@ -4,6 +4,27 @@ title: "NestJS-tRPC Documentation - Dependency Injection"
 
 import { Callout } from 'nextra/components';
 import Link from 'next/link';
+import JsonLd from '../../components/JsonLd';
+
+<JsonLd data={{
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'Dependency Injection',
+  description: 'Use NestJS dependency injection with tRPC routers, middlewares, and context providers via the @Inject decorator.',
+  url: 'https://nestjs-trpc.io/docs/dependency-injection',
+  author: { '@type': 'Person', name: 'Kevin Edry', url: 'https://kevin-edry.com' },
+  publisher: { '@type': 'Organization', name: 'NestJS tRPC', url: 'https://nestjs-trpc.io' },
+  proficiencyLevel: 'Expert',
+}} />
+<JsonLd data={{
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://nestjs-trpc.io' },
+    { '@type': 'ListItem', position: 2, name: 'Docs', item: 'https://nestjs-trpc.io/docs' },
+    { '@type': 'ListItem', position: 3, name: 'Dependency Injection', item: 'https://nestjs-trpc.io/docs/dependency-injection' },
+  ],
+}} />
 
 # Dependency injection
 

--- a/docs/pages/docs/error-handling.mdx
+++ b/docs/pages/docs/error-handling.mdx
@@ -5,6 +5,27 @@ title: "NestJS-tRPC Documentation - Error Handling"
 import { Callout, Steps } from 'nextra/components';
 import TrpcIcon from '../../public/icons/trpc.svg';
 import Link from 'next/link';
+import JsonLd from '../../components/JsonLd';
+
+<JsonLd data={{
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'Error Handling',
+  description: 'Handle tRPC errors in NestJS — configure onError handlers for logging, reporting, and side-effects on procedure failures.',
+  url: 'https://nestjs-trpc.io/docs/error-handling',
+  author: { '@type': 'Person', name: 'Kevin Edry', url: 'https://kevin-edry.com' },
+  publisher: { '@type': 'Organization', name: 'NestJS tRPC', url: 'https://nestjs-trpc.io' },
+  proficiencyLevel: 'Expert',
+}} />
+<JsonLd data={{
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://nestjs-trpc.io' },
+    { '@type': 'ListItem', position: 2, name: 'Docs', item: 'https://nestjs-trpc.io/docs' },
+    { '@type': 'ListItem', position: 3, name: 'Error Handling', item: 'https://nestjs-trpc.io/docs/error-handling' },
+  ],
+}} />
 
 # Error Handling
 

--- a/docs/pages/docs/graphql.mdx
+++ b/docs/pages/docs/graphql.mdx
@@ -3,6 +3,27 @@ title: "NestJS-tRPC Documentation - GraphQL"
 ---
 
 import { Callout} from 'nextra/components';
+import JsonLd from '../../components/JsonLd';
+
+<JsonLd data={{
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'GraphQL Migration',
+  description: 'Why and how to migrate from GraphQL to tRPC in NestJS — comparing type safety, performance, and developer experience.',
+  url: 'https://nestjs-trpc.io/docs/graphql',
+  author: { '@type': 'Person', name: 'Kevin Edry', url: 'https://kevin-edry.com' },
+  publisher: { '@type': 'Organization', name: 'NestJS tRPC', url: 'https://nestjs-trpc.io' },
+  proficiencyLevel: 'Beginner',
+}} />
+<JsonLd data={{
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://nestjs-trpc.io' },
+    { '@type': 'ListItem', position: 2, name: 'Docs', item: 'https://nestjs-trpc.io/docs' },
+    { '@type': 'ListItem', position: 3, name: 'GraphQL Migration', item: 'https://nestjs-trpc.io/docs/graphql' },
+  ],
+}} />
 
 # Why Migrate from GraphQL?
 

--- a/docs/pages/docs/index.mdx
+++ b/docs/pages/docs/index.mdx
@@ -6,6 +6,27 @@ title: "NestJS-tRPC Documentation - Installation Guide"
 import { Callout, Tabs, Steps } from 'nextra/components';
 import Link from 'next/link';
 import Table from '../../components/Table';
+import JsonLd from '../../components/JsonLd';
+
+<JsonLd data={{
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'Installation',
+  description: 'Guide to installing and setting up NestJS tRPC in your NestJS project with your preferred package manager.',
+  url: 'https://nestjs-trpc.io/docs',
+  author: { '@type': 'Person', name: 'Kevin Edry', url: 'https://kevin-edry.com' },
+  publisher: { '@type': 'Organization', name: 'NestJS tRPC', url: 'https://nestjs-trpc.io' },
+  proficiencyLevel: 'Beginner',
+}} />
+<JsonLd data={{
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://nestjs-trpc.io' },
+    { '@type': 'ListItem', position: 2, name: 'Docs', item: 'https://nestjs-trpc.io/docs' },
+    { '@type': 'ListItem', position: 3, name: 'Installation', item: 'https://nestjs-trpc.io/docs' },
+  ],
+}} />
 
 # Installation
 

--- a/docs/pages/docs/integrations.mdx
+++ b/docs/pages/docs/integrations.mdx
@@ -3,6 +3,27 @@ title: "NestJS-tRPC Documentation - Integrations"
 ---
 
 import { Callout, Steps, Tabs } from 'nextra-theme-docs';
+import JsonLd from '../../components/JsonLd';
+
+<JsonLd data={{
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'Integrations',
+  description: 'Access the AppRouter at runtime and integrate with tRPC ecosystem libraries like trpc-ui, trpc-openapi, and trpc-playground.',
+  url: 'https://nestjs-trpc.io/docs/integrations',
+  author: { '@type': 'Person', name: 'Kevin Edry', url: 'https://kevin-edry.com' },
+  publisher: { '@type': 'Organization', name: 'NestJS tRPC', url: 'https://nestjs-trpc.io' },
+  proficiencyLevel: 'Expert',
+}} />
+<JsonLd data={{
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://nestjs-trpc.io' },
+    { '@type': 'ListItem', position: 2, name: 'Docs', item: 'https://nestjs-trpc.io/docs' },
+    { '@type': 'ListItem', position: 3, name: 'Integrations', item: 'https://nestjs-trpc.io/docs/integrations' },
+  ],
+}} />
 
 # Integrations
 

--- a/docs/pages/docs/middlewares.mdx
+++ b/docs/pages/docs/middlewares.mdx
@@ -5,6 +5,27 @@ title: "NestJS-tRPC Documentation - Middlewares"
 import { Callout, Cards, Card, Tabs, Steps } from 'nextra/components'
 import NestJSIcon from '../../public/icons/nestjs.svg';
 import TrpcIcon from '../../public/icons/trpc.svg';
+import JsonLd from '../../components/JsonLd';
+
+<JsonLd data={{
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'Middlewares',
+  description: 'Add procedure middlewares to NestJS tRPC routers — router-level and procedure-level middleware with the @UseMiddlewares decorator.',
+  url: 'https://nestjs-trpc.io/docs/middlewares',
+  author: { '@type': 'Person', name: 'Kevin Edry', url: 'https://kevin-edry.com' },
+  publisher: { '@type': 'Organization', name: 'NestJS tRPC', url: 'https://nestjs-trpc.io' },
+  proficiencyLevel: 'Expert',
+}} />
+<JsonLd data={{
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://nestjs-trpc.io' },
+    { '@type': 'ListItem', position: 2, name: 'Docs', item: 'https://nestjs-trpc.io/docs' },
+    { '@type': 'ListItem', position: 3, name: 'Middlewares', item: 'https://nestjs-trpc.io/docs/middlewares' },
+  ],
+}} />
 
 # Middlewares
 

--- a/docs/pages/docs/nestjs.mdx
+++ b/docs/pages/docs/nestjs.mdx
@@ -3,7 +3,28 @@ title: "NestJS-tRPC Documentation - NestJS Quickstart Guide"
 ---
 
 import {Steps} from 'nextra/components';
-import Link from 'next/link'
+import Link from 'next/link';
+import JsonLd from '../../components/JsonLd';
+
+<JsonLd data={{
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'NestJS Quickstart',
+  description: 'Get started with NestJS — install the CLI, create a project, and understand the modular architecture before adding tRPC.',
+  url: 'https://nestjs-trpc.io/docs/nestjs',
+  author: { '@type': 'Person', name: 'Kevin Edry', url: 'https://kevin-edry.com' },
+  publisher: { '@type': 'Organization', name: 'NestJS tRPC', url: 'https://nestjs-trpc.io' },
+  proficiencyLevel: 'Beginner',
+}} />
+<JsonLd data={{
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://nestjs-trpc.io' },
+    { '@type': 'ListItem', position: 2, name: 'Docs', item: 'https://nestjs-trpc.io/docs' },
+    { '@type': 'ListItem', position: 3, name: 'NestJS Quickstart', item: 'https://nestjs-trpc.io/docs/nestjs' },
+  ],
+}} />
 
 # NestJS Quickstart Guide
 <Link href="https://nestjs.com/" rel={"nofollow"} target={"_blank"} className={"underline text-primary"}>NestJS</Link> is a progressive Node.js framework for building efficient, reliable, and scalable server-side applications. It uses TypeScript by default, which enhances productivity and maintainability. NestJS incorporates elements from Object-Oriented Programming, Functional Programming, and Functional Reactive Programming.

--- a/docs/pages/docs/routers.mdx
+++ b/docs/pages/docs/routers.mdx
@@ -7,6 +7,27 @@ import Table from "../../components/Table";
 import NestJSIcon from '../../public/icons/nestjs.svg';
 import TrpcIcon from '../../public/icons/trpc.svg';
 import Link from 'next/link';
+import JsonLd from '../../components/JsonLd';
+
+<JsonLd data={{
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'Routers',
+  description: 'Define tRPC routers in NestJS using decorators — queries, mutations, input validation with Zod, and nested routers.',
+  url: 'https://nestjs-trpc.io/docs/routers',
+  author: { '@type': 'Person', name: 'Kevin Edry', url: 'https://kevin-edry.com' },
+  publisher: { '@type': 'Organization', name: 'NestJS tRPC', url: 'https://nestjs-trpc.io' },
+  proficiencyLevel: 'Expert',
+}} />
+<JsonLd data={{
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://nestjs-trpc.io' },
+    { '@type': 'ListItem', position: 2, name: 'Docs', item: 'https://nestjs-trpc.io/docs' },
+    { '@type': 'ListItem', position: 3, name: 'Routers', item: 'https://nestjs-trpc.io/docs/routers' },
+  ],
+}} />
 
 # Routers
 

--- a/docs/pages/docs/structure.mdx
+++ b/docs/pages/docs/structure.mdx
@@ -5,6 +5,27 @@ title: "NestJS-tRPC Documentation - First Steps and Core Concepts"
 import { Callout, FileTree } from 'nextra/components';
 import Link from 'next/link';
 import Table from '../../components/Table';
+import JsonLd from '../../components/JsonLd';
+
+<JsonLd data={{
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'First Steps',
+  description: 'Learn the basic concepts and recommended file structure for NestJS tRPC — routers, middlewares, context, and module setup.',
+  url: 'https://nestjs-trpc.io/docs/structure',
+  author: { '@type': 'Person', name: 'Kevin Edry', url: 'https://kevin-edry.com' },
+  publisher: { '@type': 'Organization', name: 'NestJS tRPC', url: 'https://nestjs-trpc.io' },
+  proficiencyLevel: 'Beginner',
+}} />
+<JsonLd data={{
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://nestjs-trpc.io' },
+    { '@type': 'ListItem', position: 2, name: 'Docs', item: 'https://nestjs-trpc.io/docs' },
+    { '@type': 'ListItem', position: 3, name: 'First Steps', item: 'https://nestjs-trpc.io/docs/structure' },
+  ],
+}} />
 
 # First Steps and Core Concepts
 

--- a/docs/pages/docs/subscriptions.mdx
+++ b/docs/pages/docs/subscriptions.mdx
@@ -6,6 +6,27 @@ import { Cards, Card, Callout, Tabs } from 'nextra/components';
 import Table from "../../components/Table";
 import TrpcIcon from '../../public/icons/trpc.svg';
 import Link from 'next/link';
+import JsonLd from '../../components/JsonLd';
+
+<JsonLd data={{
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'Subscriptions',
+  description: 'Stream real-time data with tRPC subscriptions in NestJS using Server-Sent Events and async generators.',
+  url: 'https://nestjs-trpc.io/docs/subscriptions',
+  author: { '@type': 'Person', name: 'Kevin Edry', url: 'https://kevin-edry.com' },
+  publisher: { '@type': 'Organization', name: 'NestJS tRPC', url: 'https://nestjs-trpc.io' },
+  proficiencyLevel: 'Expert',
+}} />
+<JsonLd data={{
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://nestjs-trpc.io' },
+    { '@type': 'ListItem', position: 2, name: 'Docs', item: 'https://nestjs-trpc.io/docs' },
+    { '@type': 'ListItem', position: 3, name: 'Subscriptions', item: 'https://nestjs-trpc.io/docs/subscriptions' },
+  ],
+}} />
 
 # Subscriptions
 

--- a/docs/pages/docs/trpc.mdx
+++ b/docs/pages/docs/trpc.mdx
@@ -2,6 +2,28 @@
 title: "NestJS-tRPC Documentation - tRPC Guide and Concepts"
 ---
 
+import JsonLd from '../../components/JsonLd';
+
+<JsonLd data={{
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'tRPC Concepts',
+  description: 'Learn core tRPC concepts including routers, procedures, type inference, and how tRPC achieves end-to-end type safety.',
+  url: 'https://nestjs-trpc.io/docs/trpc',
+  author: { '@type': 'Person', name: 'Kevin Edry', url: 'https://kevin-edry.com' },
+  publisher: { '@type': 'Organization', name: 'NestJS tRPC', url: 'https://nestjs-trpc.io' },
+  proficiencyLevel: 'Beginner',
+}} />
+<JsonLd data={{
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://nestjs-trpc.io' },
+    { '@type': 'ListItem', position: 2, name: 'Docs', item: 'https://nestjs-trpc.io/docs' },
+    { '@type': 'ListItem', position: 3, name: 'tRPC Concepts', item: 'https://nestjs-trpc.io/docs/trpc' },
+  ],
+}} />
+
 # tRPC Core Concepts
 
 ### What is tRPC?

--- a/docs/theme.config.jsx
+++ b/docs/theme.config.jsx
@@ -1,6 +1,28 @@
 import { Footer } from './components/Footer';
 
 export default {
+  head: (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'WebSite',
+        name: 'NestJS tRPC',
+        url: 'https://nestjs-trpc.io',
+        description: 'Build end-to-end type-safe APIs in NestJS using tRPC decorators.',
+        publisher: { '@type': 'Person', name: 'Kevin Edry', url: 'https://kevin-edry.com' },
+      })}} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'SoftwareApplication',
+        name: 'NestJS tRPC',
+        applicationCategory: 'DeveloperApplication',
+        operatingSystem: 'Cross-platform',
+        url: 'https://nestjs-trpc.io',
+        offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+        author: { '@type': 'Person', name: 'Kevin Edry', url: 'https://kevin-edry.com' },
+      })}} />
+    </>
+  ),
   logo: <div className={"md:nx-inline-flex nx-gap-2 nx-items-center nx-font-bold"}><img src={'/logo.png'} alt={'nestjs-trpc logo'} width={40} /> NestJS tRPC</div>,
   primaryHue: 200,
   primarySaturation: 100,


### PR DESCRIPTION
## Summary

Add comprehensive JSON-LD structured data across the documentation site to improve search engine understanding and rich result eligibility.

## Changes

- Add global `WebSite` and `SoftwareApplication` JSON-LD schemas via `head` property in `docs/theme.config.jsx`, injected on every page
- Add `TechArticle` JSON-LD to all 13 documentation pages with headline, description, author, publisher, and proficiency level
- Add `BreadcrumbList` JSON-LD to all 13 documentation pages showing Home > Docs > Page Title navigation path
- Reuse existing `JsonLd` component from `docs/components/JsonLd/index.tsx`