### PR TITLE
fix(ci): use bun pm pack in release dry-run step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
         working-directory: packages/nestjs-trpc
         run: |
           echo "DRY RUN: Would publish to npm"
-          bun pack
+          bun pm pack
 
       - name: Prepare release assets
         run: |


### PR DESCRIPTION
## Summary

The release workflow's dry-run step ran `bun pack`, which Bun interprets as a script name and fails with `Script not found "pack"`. This caused every dry-run of the release workflow to fail at packaging (the real publish path uses `bun publish` and is unaffected).

Switch to the correct `bun pm pack` command so dry-runs actually validate packaging.

## Changes

- `.github/workflows/release.yml`: `bun pack` → `bun pm pack` in the dry-run step

## Verification

Triggered a dry-run on this branch ([run 27643788080](https://github.com/KevinEdry/nestjs-trpc/actions/runs/27643788080)) — all 5 cross-platform CLI builds and the publish job pass, and `bun pm pack` correctly packs the package.