### PR TITLE
ci: publish via bunx npm to enable trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -129,9 +130,7 @@ jobs:
       - name: Publish to npm
         if: ${{ github.event_name == 'push' || !inputs.dry_run }}
         working-directory: packages/nestjs-trpc
-        run: bun publish --access public
-        env:
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: bunx npm@latest publish --provenance --access public
 
       - name: Publish to npm (dry run)
         if: ${{ github.event_name != 'push' && inputs.dry_run }}


### PR DESCRIPTION
## Summary

Switch the release workflow's publish step to use npm's OIDC trusted publishing instead of a stored `NPM_TOKEN`.

`bun publish` does not support npm's OIDC trusted publishing ([oven-sh/bun#22423](https://github.com/oven-sh/bun/issues/22423), [oven-sh/bun#15601](https://github.com/oven-sh/bun/issues/15601)), so the publish step fails auth (`404 Not Found`) even with a trusted publisher configured on the package. The documented workaround is to run npm under the Bun toolchain via `bunx`.

## Changes

- `.github/workflows/release.yml`:
  - Grant the `publish` job `id-token: write` (required for the OIDC token exchange)
  - Publish via `bunx npm@latest publish --provenance --access public` (npm ≥ 11.5.1 performs the OIDC handshake and emits provenance)
  - Drop the `NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}` env — trusted publishing uses short-lived OIDC credentials, no stored token

## Notes

- Requires the npm **Trusted Publisher** to be configured on the `nestjs-trpc` package (GitHub Actions / KevinEdry / nestjs-trpc / workflow `release.yml`) — already done.
- After merge, the `v2.10.0` release must be re-tagged onto the new `main` HEAD, since tag-triggered runs use the workflow file from the tag's commit.