### PR TITLE
feat(cli): infer procedure output type from resolver return type

### DIFF
--- a/docs/pages/docs/routers.mdx
+++ b/docs/pages/docs/routers.mdx
@@ -136,6 +136,21 @@ This can be done by using the right decorator, here is a list of the available p
 tRPC procedures may define validation logic for their input and/or output, and validators are also used to infer the types of inputs and outputs in the client-side.
 We can pass those schemas directly to the decorator as shown above.<br/>For more information on how tRPC procedure validation works, check their <Link href={"https://trpc.io/docs/server/validators"} className="underline" target="_blank">official documentation page</Link>.
 
+<Callout>
+  **`output` is optional.** When you omit it, the procedure's output type is inferred from the resolver method's return type — just like native tRPC — so you don't have to restate your service's return type as a schema:
+
+  ```typescript
+  @Query()
+  list() {
+    return this.folderService.getFolders(); // output type is inferred on the client
+  }
+  ```
+
+  A provided `output` still takes priority and adds runtime validation; inference only supplies the static type. A few caveats:
+  - Inference relies on TypeScript's `ReturnType<>`, so the resolver's return type must be **exported / nameable**. Returning a non-exported `interface`/`type` can break the generated `AppRouter` under `declaration: true` (`TS4023`/`TS2883`) — export the type or use an explicit `output` schema.
+  - It applies only to routers exported by name (`export class FooRouter`); non-exported and default-exported routers keep the previous behavior.
+</Callout>
+
 Procedures can also define a `meta` object that can be read by middlewares. This is the tRPC-idiomatic way to implement authorization and other cross-cutting concerns, similar to how NestJS guards use decorator metadata. See the <Link href={"/docs/middlewares#procedure-metadata"} className="underline">Procedure Metadata</Link> section in the Middlewares guide for details.
 
 ##### Middlewares

--- a/packages/nestjs-trpc/cli/src/generation.rs
+++ b/packages/nestjs-trpc/cli/src/generation.rs
@@ -10,8 +10,9 @@ use crate::parser::decorator::collect_schema_identifiers;
 use crate::parser::module::TransformerInfo;
 use crate::{
     build_imports_map, extract_procedures_from_class, flatten_zod_schema, DecoratorParser,
-    FileScanner, ParsedFile, ParserError, ProcedureMetadata, RouterMetadata, RouterParser,
-    ServerGenerator, StaticGenerator, SyntaxDiagnostic, TsParser,
+    FileScanner, OutputInference, ParsedFile, ParserError, ProcedureMetadata, RouterExportKind,
+    RouterInfo, RouterMetadata, RouterParser, ServerGenerator, StaticGenerator, SyntaxDiagnostic,
+    TsParser,
 };
 use std::collections::HashSet;
 use swc_ecma_ast::{Decl, ModuleDecl, ModuleItem, Stmt};
@@ -147,11 +148,13 @@ fn extract_routers(parsed_files: &[ParsedFile]) -> Result<Vec<RouterMetadata>> {
         let router_infos = router_parser.extract_routers(parsed_file);
 
         for router_info in router_infos {
-            let procedures = extract_procedures_from_class(
+            let mut procedures = extract_procedures_from_class(
                 parsed_file,
                 &router_info.class_name,
                 &decorator_parser,
             );
+
+            apply_output_inference(&mut procedures, &router_info);
 
             let router_metadata = RouterMetadata {
                 name: router_info.class_name,
@@ -186,6 +189,23 @@ fn extract_routers(parsed_files: &[ParsedFile]) -> Result<Vec<RouterMetadata>> {
     );
 
     Ok(routers)
+}
+
+fn apply_output_inference(procedures: &mut [ProcedureMetadata], router_info: &RouterInfo) {
+    if router_info.export_kind != RouterExportKind::Named {
+        return;
+    }
+
+    for procedure in procedures.iter_mut() {
+        if procedure.output_schema.is_some() {
+            continue;
+        }
+
+        procedure.output_inference = Some(OutputInference {
+            router_class_name: router_info.class_name.clone(),
+            router_file_path: router_info.file_path.clone(),
+        });
+    }
 }
 
 fn build_schema_locations(

--- a/packages/nestjs-trpc/cli/src/generator/mod.rs
+++ b/packages/nestjs-trpc/cli/src/generator/mod.rs
@@ -150,6 +150,31 @@ impl StaticGenerator {
     where
         I: IntoIterator<Item = &'a str>,
     {
+        self.render_named_imports("import", schema_names, schema_locations, output_file_path)
+    }
+
+    pub fn generate_type_imports<'a, I>(
+        &self,
+        type_names: I,
+        type_locations: &std::collections::HashMap<String, std::path::PathBuf>,
+        output_file_path: &Path,
+    ) -> String
+    where
+        I: IntoIterator<Item = &'a str>,
+    {
+        self.render_named_imports("import type", type_names, type_locations, output_file_path)
+    }
+
+    fn render_named_imports<'a, I>(
+        &self,
+        keyword: &str,
+        names: I,
+        locations: &std::collections::HashMap<String, std::path::PathBuf>,
+        output_file_path: &Path,
+    ) -> String
+    where
+        I: IntoIterator<Item = &'a str>,
+    {
         let output_dir = output_file_path.parent().unwrap_or_else(|| Path::new("."));
 
         let mut seen_names: HashSet<&str> = HashSet::new();
@@ -158,8 +183,8 @@ impl StaticGenerator {
             std::collections::HashMap::new();
 
         group_schema_names_by_path(
-            schema_names,
-            schema_locations,
+            names,
+            locations,
             output_dir,
             &mut seen_names,
             &mut path_order,
@@ -175,7 +200,7 @@ impl StaticGenerator {
                 let names = names_by_path.get(path)?;
                 let names_joined = names.join(", ");
                 Some(format!(
-                    "import {{ {names_joined} }} from {q}{path}{q}{term}\n"
+                    "{keyword} {{ {names_joined} }} from {q}{path}{q}{term}\n"
                 ))
             })
             .collect()

--- a/packages/nestjs-trpc/cli/src/generator/server.rs
+++ b/packages/nestjs-trpc/cli/src/generator/server.rs
@@ -1,7 +1,7 @@
 use crate::generator::StaticGenerator;
-use crate::{ProcedureMetadata, RouterMetadata};
+use crate::{OutputInference, ProcedureMetadata, RouterMetadata};
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 const GENERATED_FILE_HEADER: &str = "\
 /**
@@ -101,6 +101,8 @@ impl ServerGenerator {
             output_file_path,
         );
 
+        self.append_output_inference_imports(&mut output, routers, output_file_path);
+
         output.push('\n');
 
         output.push_str(&self.generate_app_router(routers));
@@ -197,11 +199,32 @@ impl ServerGenerator {
         }
 
         let proc_type = procedure.procedure_type.to_string();
+        let output_cast = self.output_cast(procedure);
         chain_parts.push(format!(
-            "{chain_indent}.{proc_type}(async () => \"PLACEHOLDER_DO_NOT_REMOVE\" as any)"
+            "{chain_indent}.{proc_type}(async () => \"PLACEHOLDER_DO_NOT_REMOVE\" as {output_cast})"
         ));
 
         chain_parts.join("\n")
+    }
+
+    fn output_cast(&self, procedure: &ProcedureMetadata) -> String {
+        if procedure.output_schema.is_some() {
+            return "any".to_string();
+        }
+
+        let Some(inference) = procedure.output_inference.as_ref() else {
+            return "any".to_string();
+        };
+
+        let quote = if self.static_generator.use_single_quotes {
+            '\''
+        } else {
+            '"'
+        };
+        let class_name = &inference.router_class_name;
+        let method_name = &procedure.name;
+
+        format!("unknown as Awaited<ReturnType<{class_name}[{quote}{method_name}{quote}]>>")
     }
 
     #[must_use]
@@ -245,6 +268,42 @@ impl ServerGenerator {
 
         if !schema_imports.is_empty() {
             output.push_str(&schema_imports);
+        }
+    }
+
+    fn append_output_inference_imports(
+        &self,
+        output: &mut String,
+        routers: &[RouterMetadata],
+        output_file_path: &Path,
+    ) {
+        let inferences: Vec<&OutputInference> = routers
+            .iter()
+            .flat_map(|router| &router.procedures)
+            .filter_map(|procedure| procedure.output_inference.as_ref())
+            .collect();
+
+        if inferences.is_empty() {
+            return;
+        }
+
+        let mut type_locations: HashMap<String, PathBuf> = HashMap::new();
+        for inference in &inferences {
+            type_locations
+                .entry(inference.router_class_name.clone())
+                .or_insert_with(|| inference.router_file_path.clone());
+        }
+
+        let type_imports = self.static_generator.generate_type_imports(
+            inferences
+                .iter()
+                .map(|inference| inference.router_class_name.as_str()),
+            &type_locations,
+            output_file_path,
+        );
+
+        if !type_imports.is_empty() {
+            output.push_str(&type_imports);
         }
     }
 }
@@ -303,6 +362,29 @@ mod tests {
             input_schema_ref: None,
             output_schema_ref: None,
             schema_identifiers: Vec::new(),
+            output_inference: None,
+        }
+    }
+
+    fn create_inferred_procedure(
+        name: &str,
+        proc_type: ProcedureType,
+        router_class_name: &str,
+        router_file_path: &str,
+    ) -> ProcedureMetadata {
+        use crate::OutputInference;
+        ProcedureMetadata {
+            name: name.to_string(),
+            procedure_type: proc_type,
+            input_schema: None,
+            output_schema: None,
+            input_schema_ref: None,
+            output_schema_ref: None,
+            schema_identifiers: Vec::new(),
+            output_inference: Some(OutputInference {
+                router_class_name: router_class_name.to_string(),
+                router_file_path: std::path::PathBuf::from(router_file_path),
+            }),
         }
     }
 
@@ -810,6 +892,7 @@ mod tests {
             input_schema_ref: None,
             output_schema_ref: None,
             schema_identifiers: Vec::new(),
+            output_inference: None,
         };
 
         let output = generator.generate_procedure_string(&procedure, 1);
@@ -844,6 +927,7 @@ mod tests {
                 input_schema_ref: Some("userInputSchema".to_string()),
                 output_schema_ref: None,
                 schema_identifiers: Vec::new(),
+                output_inference: None,
             }],
         )];
 
@@ -945,6 +1029,7 @@ mod tests {
             input_schema_ref: Some("InputRef".to_string()),
             output_schema_ref: Some("OutputRef".to_string()),
             schema_identifiers: Vec::new(),
+            output_inference: None,
         };
 
         let refs = ServerGenerator::extract_schema_refs(&procedure);
@@ -963,6 +1048,7 @@ mod tests {
             input_schema_ref: None,
             output_schema_ref: None,
             schema_identifiers: Vec::new(),
+            output_inference: None,
         };
 
         let refs = ServerGenerator::extract_schema_refs(&procedure);
@@ -1259,5 +1345,75 @@ mod tests {
         assert!(output.contains("const t = initTRPC.create();"));
         assert!(!output.contains("transformer"));
         assert!(!output.contains("superjson"));
+    }
+
+    #[test]
+    fn test_inferred_output_emits_return_type_cast() {
+        let generator = ServerGenerator::new();
+        let procedure = create_inferred_procedure(
+            "list",
+            ProcedureType::Query,
+            "FolderRouter",
+            "folder.router.ts",
+        );
+
+        let output = generator.generate_procedure_string(&procedure, 1);
+
+        assert!(output.contains(
+            ".query(async () => \"PLACEHOLDER_DO_NOT_REMOVE\" as unknown as Awaited<ReturnType<FolderRouter[\"list\"]>>)"
+        ));
+    }
+
+    #[test]
+    fn test_explicit_output_overrides_inference() {
+        let generator = ServerGenerator::new();
+        let mut procedure = create_inferred_procedure(
+            "list",
+            ProcedureType::Query,
+            "FolderRouter",
+            "folder.router.ts",
+        );
+        procedure.output_schema = Some("folderSchema".to_string());
+
+        let output = generator.generate_procedure_string(&procedure, 1);
+
+        assert!(output.contains(".output(folderSchema)"));
+        assert!(output.contains(".query(async () => \"PLACEHOLDER_DO_NOT_REMOVE\" as any)"));
+        assert!(!output.contains("ReturnType"));
+    }
+
+    #[test]
+    fn test_no_inference_falls_back_to_any() {
+        let generator = ServerGenerator::new();
+        let procedure = create_test_procedure("list", ProcedureType::Query, None, None);
+
+        let output = generator.generate_procedure_string(&procedure, 1);
+
+        assert!(output.contains(".query(async () => \"PLACEHOLDER_DO_NOT_REMOVE\" as any)"));
+        assert!(!output.contains("ReturnType"));
+    }
+
+    #[test]
+    fn test_inferred_output_emits_router_type_import() {
+        let generator = ServerGenerator::new();
+        let routers = vec![create_test_router(
+            "FolderRouter",
+            Some("folders"),
+            vec![create_inferred_procedure(
+                "list",
+                ProcedureType::Query,
+                "FolderRouter",
+                "folder.router.ts",
+            )],
+        )];
+
+        let output = generator.generate_with_schema_imports(
+            &routers,
+            &HashMap::new(),
+            Path::new("server.ts"),
+        );
+
+        assert!(output.contains("import type { FolderRouter } from \"./folder.router\";"));
+        assert!(output.contains("Awaited<ReturnType<FolderRouter[\"list\"]>>"));
     }
 }

--- a/packages/nestjs-trpc/cli/src/lib.rs
+++ b/packages/nestjs-trpc/cli/src/lib.rs
@@ -33,8 +33,8 @@ pub use parser::{
     extract_trpc_options, flatten_zod_schema, is_procedure_decorator, parse_typescript_file,
     parse_typescript_source, resolve_context_file, resolve_transformer_import, ContextInfo,
     ContextParser, ContextProperty, DecoratorParser, MiddlewareInfo, MiddlewareParser,
-    ModuleParser, ParsedFile, ProcedureDecoratorInfo, RouterInfo, RouterParser, TransformerInfo,
-    TrpcModuleOptions, TsParser, ZodFlattener, ZodResult,
+    ModuleParser, ParsedFile, ProcedureDecoratorInfo, RouterExportKind, RouterInfo, RouterParser,
+    TransformerInfo, TrpcModuleOptions, TsParser, ZodFlattener, ZodResult,
 };
 pub use scanner::{scan_for_routers, FileScanner};
 pub use validation::{
@@ -59,6 +59,18 @@ pub struct ProcedureMetadata {
     pub input_schema_ref: Option<String>,
     pub output_schema_ref: Option<String>,
     pub schema_identifiers: Vec<String>,
+
+    /// When no explicit `output` schema is provided, the procedure output type is
+    /// inferred from the resolver method's return type via `ReturnType<>` in the
+    /// generated file. This is only populated for routers that can be imported by
+    /// name; it stays `None` for non-exported or default-exported routers.
+    pub output_inference: Option<OutputInference>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutputInference {
+    pub router_class_name: String,
+    pub router_file_path: std::path::PathBuf,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/packages/nestjs-trpc/cli/src/parser/mod.rs
+++ b/packages/nestjs-trpc/cli/src/parser/mod.rs
@@ -229,7 +229,7 @@ pub use module::{
     TransformerInfo, TrpcModuleOptions,
 };
 pub use procedure::extract_procedures_from_class;
-pub use router::{extract_routers, RouterInfo, RouterParser};
+pub use router::{extract_routers, RouterExportKind, RouterInfo, RouterParser};
 pub use schema::{flatten_zod_schema, ZodFlattener, ZodResult};
 
 #[cfg(test)]

--- a/packages/nestjs-trpc/cli/src/parser/procedure.rs
+++ b/packages/nestjs-trpc/cli/src/parser/procedure.rs
@@ -108,6 +108,7 @@ fn extract_procedures_from_class_body(
                 input_schema_ref: info.input_ref,
                 output_schema_ref: info.output_ref,
                 schema_identifiers: info.schema_identifiers,
+                output_inference: None,
             });
         }
     }

--- a/packages/nestjs-trpc/cli/src/parser/router.rs
+++ b/packages/nestjs-trpc/cli/src/parser/router.rs
@@ -6,6 +6,13 @@ use swc_ecma_ast::{
 };
 use tracing::{debug, trace};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RouterExportKind {
+    Named,
+    Default,
+    None,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RouterInfo {
     pub class_name: String,
@@ -13,6 +20,8 @@ pub struct RouterInfo {
     pub alias: Option<String>,
 
     pub file_path: PathBuf,
+
+    pub export_kind: RouterExportKind,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -61,6 +70,7 @@ impl RouterParser {
                     &class_declaration.ident.sym,
                     &class_declaration.class,
                     file_path,
+                    RouterExportKind::None,
                 )
             }
             ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultDecl(export_default)) => {
@@ -79,6 +89,7 @@ impl RouterParser {
             &class_declaration.ident.sym,
             &class_declaration.class,
             file_path,
+            RouterExportKind::Named,
         )
     }
 
@@ -95,13 +106,19 @@ impl RouterParser {
             |identifier| identifier.sym.to_string(),
         );
 
-        Self::extract_router_from_class(&class_name, &class_expression.class, file_path)
+        Self::extract_router_from_class(
+            &class_name,
+            &class_expression.class,
+            file_path,
+            RouterExportKind::Default,
+        )
     }
 
     fn extract_router_from_class(
         class_name: &str,
         class: &Class,
         file_path: &Path,
+        export_kind: RouterExportKind,
     ) -> Option<RouterInfo> {
         trace!(class = %class_name, "Checking class for @Router decorator");
 
@@ -113,6 +130,7 @@ impl RouterParser {
                 class_name: class_name.to_string(),
                 alias,
                 file_path: file_path.to_path_buf(),
+                export_kind,
             })
     }
 
@@ -304,6 +322,7 @@ mod tests {
         assert_eq!(routers.len(), 1);
         assert_eq!(routers[0].class_name, "UserRouter");
         assert_eq!(routers[0].alias, None);
+        assert_eq!(routers[0].export_kind, RouterExportKind::Named);
     }
 
     #[test]
@@ -344,6 +363,7 @@ mod tests {
         assert_eq!(routers.len(), 1);
         assert_eq!(routers[0].class_name, "InternalRouter");
         assert_eq!(routers[0].alias, Some("internal".to_string()));
+        assert_eq!(routers[0].export_kind, RouterExportKind::None);
     }
 
     #[test]
@@ -503,11 +523,13 @@ mod tests {
             class_name: "Test".to_string(),
             alias: Some("test".to_string()),
             file_path: PathBuf::from("test.ts"),
+            export_kind: RouterExportKind::Named,
         };
         let info2 = RouterInfo {
             class_name: "Test".to_string(),
             alias: Some("test".to_string()),
             file_path: PathBuf::from("test.ts"),
+            export_kind: RouterExportKind::Named,
         };
         assert_eq!(info1, info2);
     }
@@ -518,6 +540,7 @@ mod tests {
             class_name: "Test".to_string(),
             alias: Some("test".to_string()),
             file_path: PathBuf::from("test.ts"),
+            export_kind: RouterExportKind::Named,
         };
         let cloned = info.clone();
         assert_eq!(info, cloned);
@@ -529,6 +552,7 @@ mod tests {
             class_name: "Test".to_string(),
             alias: Some("test".to_string()),
             file_path: PathBuf::from("test.ts"),
+            export_kind: RouterExportKind::Named,
         };
         let debug_str = format!("{info:?}");
         assert!(debug_str.contains("Test"));
@@ -605,5 +629,6 @@ mod tests {
         assert_eq!(routers.len(), 1);
         assert_eq!(routers[0].class_name, "DefaultRouter");
         assert_eq!(routers[0].alias, Some("default".to_string()));
+        assert_eq!(routers[0].export_kind, RouterExportKind::Default);
     }
 }

--- a/packages/nestjs-trpc/cli/tests/fixtures/non-exported-router/items.router.ts
+++ b/packages/nestjs-trpc/cli/tests/fixtures/non-exported-router/items.router.ts
@@ -1,0 +1,12 @@
+import { Router, Query } from 'nestjs-trpc';
+import { z } from 'zod';
+
+@Router({ alias: 'items' })
+class ItemsRouter {
+    @Query({
+        input: z.object({ id: z.string() }),
+    })
+    getItem(id: string) {
+        return { id, name: 'Item' };
+    }
+}

--- a/packages/nestjs-trpc/cli/tests/fixtures/output-inference/folder.router.ts
+++ b/packages/nestjs-trpc/cli/tests/fixtures/output-inference/folder.router.ts
@@ -1,0 +1,21 @@
+import { Router, Query, Mutation } from 'nestjs-trpc';
+import { z } from 'zod';
+import { Folder } from './folder.types';
+
+@Router({ alias: 'folders' })
+export class FolderRouter {
+    @Query()
+    list(): Folder[] {
+        return [];
+    }
+
+    @Query({ output: z.object({ id: z.string() }) })
+    getById(id: string) {
+        return { id };
+    }
+
+    @Mutation()
+    create() {
+        return { id: '1', name: 'New', parentId: null };
+    }
+}

--- a/packages/nestjs-trpc/cli/tests/fixtures/output-inference/folder.types.ts
+++ b/packages/nestjs-trpc/cli/tests/fixtures/output-inference/folder.types.ts
@@ -1,0 +1,5 @@
+export interface Folder {
+    id: string;
+    name: string;
+    parentId: string | null;
+}

--- a/packages/nestjs-trpc/cli/tests/generation.rs
+++ b/packages/nestjs-trpc/cli/tests/generation.rs
@@ -83,6 +83,30 @@ fn snapshot_subscription() {
 }
 
 #[test]
+fn snapshot_output_inference() {
+    let output = run_generation_on_fixture("output-inference");
+    assert_snapshot!("output_inference", output);
+}
+
+#[test]
+fn non_exported_router_falls_back_to_any() {
+    let output = run_generation_on_fixture("non-exported-router");
+
+    assert!(
+        output.contains(".query(async () => \"PLACEHOLDER_DO_NOT_REMOVE\" as any)"),
+        "Non-exported routers cannot be imported by name, so output inference must fall back to `any`:\n{output}"
+    );
+    assert!(
+        !output.contains("import type"),
+        "Non-exported routers must not produce a router type import:\n{output}"
+    );
+    assert!(
+        !output.contains("ReturnType"),
+        "Non-exported routers must not emit a ReturnType inference:\n{output}"
+    );
+}
+
+#[test]
 fn snapshot_path_aliases() {
     let output = run_generation_on_fixture("path-aliases");
     assert_snapshot!("path_aliases", output);

--- a/packages/nestjs-trpc/cli/tests/snapshots/generation__enum_literals.snap
+++ b/packages/nestjs-trpc/cli/tests/snapshots/generation__enum_literals.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/generation.rs
+assertion_line: 76
 expression: output
 ---
 /**
@@ -18,6 +19,7 @@ import { z } from "zod";
 const t = initTRPC.create();
 const publicProcedure = t.procedure;
 import { Priority, Status, TypeEnum } from "<FIXTURES>/enum-literals/types";
+import type { ItemsRouter } from "<FIXTURES>/enum-literals/items.router";
 
 const appRouter = t.router({
   items: t.router({
@@ -34,7 +36,7 @@ const appRouter = t.router({
       .input(z.object({
             type: z.enum([TypeEnum.Normal, TypeEnum.Special]),
         }))
-      .mutation(async () => "PLACEHOLDER_DO_NOT_REMOVE" as any)
+      .mutation(async () => "PLACEHOLDER_DO_NOT_REMOVE" as unknown as Awaited<ReturnType<ItemsRouter["createItem"]>>)
     })
 });
 

--- a/packages/nestjs-trpc/cli/tests/snapshots/generation__external_imports.snap
+++ b/packages/nestjs-trpc/cli/tests/snapshots/generation__external_imports.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/generation.rs
-assertion_line: 86
+assertion_line: 94
 expression: output
 ---
 /**
@@ -20,6 +20,7 @@ const t = initTRPC.create();
 const publicProcedure = t.procedure;
 import { orderSchema } from "shared-schemas";
 import { paymentSchema } from "@myorg/payment-types";
+import type { OrdersRouter } from "<FIXTURES>/external-imports/orders.router";
 
 const appRouter = t.router({
   orders: t.router({
@@ -29,7 +30,7 @@ const appRouter = t.router({
       .query(async () => "PLACEHOLDER_DO_NOT_REMOVE" as any),
     processPayment: publicProcedure
       .input(paymentSchema)
-      .mutation(async () => "PLACEHOLDER_DO_NOT_REMOVE" as any)
+      .mutation(async () => "PLACEHOLDER_DO_NOT_REMOVE" as unknown as Awaited<ReturnType<OrdersRouter["processPayment"]>>)
     })
 });
 

--- a/packages/nestjs-trpc/cli/tests/snapshots/generation__output_inference.snap
+++ b/packages/nestjs-trpc/cli/tests/snapshots/generation__output_inference.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/generation.rs
-assertion_line: 197
+assertion_line: 88
 expression: output
 ---
 /**
@@ -15,21 +15,20 @@ expression: output
 
 import { initTRPC } from "@trpc/server";
 import { z } from "zod";
-import superjson from "superjson";
 
-const t = initTRPC.create({ transformer: superjson });
+const t = initTRPC.create();
 const publicProcedure = t.procedure;
-import type { ItemsRouter } from "<FIXTURES>/transformer-library/items.router";
+import type { FolderRouter } from "<FIXTURES>/output-inference/folder.router";
 
 const appRouter = t.router({
-  items: t.router({
-    getItem: publicProcedure
-      .input(z.object({ id: z.string() }))
-      .output(z.object({ id: z.string(), name: z.string() }))
+  folders: t.router({
+    list: publicProcedure
+      .query(async () => "PLACEHOLDER_DO_NOT_REMOVE" as unknown as Awaited<ReturnType<FolderRouter["list"]>>),
+    getById: publicProcedure
+      .output(z.object({ id: z.string() }))
       .query(async () => "PLACEHOLDER_DO_NOT_REMOVE" as any),
-    createItem: publicProcedure
-      .input(z.object({ name: z.string() }))
-      .mutation(async () => "PLACEHOLDER_DO_NOT_REMOVE" as unknown as Awaited<ReturnType<ItemsRouter["createItem"]>>)
+    create: publicProcedure
+      .mutation(async () => "PLACEHOLDER_DO_NOT_REMOVE" as unknown as Awaited<ReturnType<FolderRouter["create"]>>)
     })
 });
 

--- a/packages/nestjs-trpc/cli/tests/snapshots/generation__transformer_from_local_file.snap
+++ b/packages/nestjs-trpc/cli/tests/snapshots/generation__transformer_from_local_file.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/generation.rs
+assertion_line: 203
 expression: output
 ---
 /**
@@ -18,12 +19,13 @@ import { customTransformer } from "./my-transformer";
 
 const t = initTRPC.create({ transformer: customTransformer });
 const publicProcedure = t.procedure;
+import type { ItemsRouter } from "<FIXTURES>/transformer-local/items.router";
 
 const appRouter = t.router({
   items: t.router({
     getItem: publicProcedure
       .input(z.object({ id: z.string() }))
-      .query(async () => "PLACEHOLDER_DO_NOT_REMOVE" as any)
+      .query(async () => "PLACEHOLDER_DO_NOT_REMOVE" as unknown as Awaited<ReturnType<ItemsRouter["getItem"]>>)
     })
 });
 

--- a/packages/nestjs-trpc/cli/tests/validation.rs
+++ b/packages/nestjs-trpc/cli/tests/validation.rs
@@ -62,7 +62,12 @@ fn build_tsconfig(nestjs_trpc_node_modules: &std::path::Path) -> String {
     )
 }
 
-fn create_stub_declarations(output_directory: &std::path::Path, generated_content: &str) {
+fn create_stub_declarations(
+    output_directory: &std::path::Path,
+    generated_content: &str,
+    fixture_path: &std::path::Path,
+) {
+    use std::collections::HashSet;
     use std::fmt::Write;
 
     let stub_names = extract_schema_references(generated_content);
@@ -73,6 +78,11 @@ fn create_stub_declarations(output_directory: &std::path::Path, generated_conten
     for name in stub_names {
         writeln!(declarations, "declare const {name}: any;").unwrap();
     }
+
+    let mut declared_modules: HashSet<String> = ["@trpc/server", "zod"]
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
     for module_specifier in &external_modules {
         writeln!(declarations, "declare module \"{module_specifier}\" {{").unwrap();
         let names = extract_import_names_for_module(generated_content, module_specifier);
@@ -80,10 +90,62 @@ fn create_stub_declarations(output_directory: &std::path::Path, generated_conten
             writeln!(declarations, "  export const {name}: any;").unwrap();
         }
         writeln!(declarations, "}}").unwrap();
+        declared_modules.insert(module_specifier.clone());
+    }
+
+    // The generated file imports router classes for output-type inference, so tsc
+    // type-checks those router files transitively. Stub the bare-package modules they
+    // import (e.g. `nestjs-trpc`) that aren't already declared above.
+    for module_specifier in collect_router_file_modules(fixture_path) {
+        if declared_modules.contains(&module_specifier) {
+            continue;
+        }
+        writeln!(declarations, "declare module \"{module_specifier}\";").unwrap();
+        declared_modules.insert(module_specifier);
     }
 
     let stub_path = output_directory.join("stubs.d.ts");
     fs::write(&stub_path, declarations).expect("Failed to write stub declarations");
+}
+
+fn collect_router_file_modules(fixture_path: &std::path::Path) -> Vec<String> {
+    use std::collections::HashSet;
+
+    let mut modules: HashSet<String> = HashSet::new();
+    collect_router_file_modules_recursive(fixture_path, &mut modules);
+    modules.into_iter().collect()
+}
+
+fn collect_router_file_modules_recursive(
+    directory: &std::path::Path,
+    modules: &mut std::collections::HashSet<String>,
+) {
+    let Ok(entries) = fs::read_dir(directory) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_router_file_modules_recursive(&path, modules);
+            continue;
+        }
+
+        let is_router_file = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.ends_with(".router.ts"));
+        if !is_router_file {
+            continue;
+        }
+
+        let Ok(content) = fs::read_to_string(&path) else {
+            continue;
+        };
+        for module_specifier in extract_external_module_specifiers(&content) {
+            modules.insert(module_specifier);
+        }
+    }
 }
 
 fn extract_external_module_specifiers(content: &str) -> Vec<String> {
@@ -274,7 +336,7 @@ fn generate_and_validate_typescript(fixture_name: &str) {
     let server_file = output_path.join("server.ts");
     let generated_content = fs::read_to_string(&server_file).expect("Failed to read server.ts");
 
-    create_stub_declarations(output_path, &generated_content);
+    create_stub_declarations(output_path, &generated_content, &fixture_path);
 
     let nestjs_trpc_node_modules = nestjs_trpc_package();
     let tsconfig_content = build_tsconfig(&nestjs_trpc_node_modules);
@@ -340,6 +402,11 @@ fn validate_enum_literals_compile() {
 #[test]
 fn validate_external_imports_compile() {
     generate_and_validate_typescript("external-imports");
+}
+
+#[test]
+fn validate_output_inference_compiles() {
+    generate_and_validate_typescript("output-inference");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #106.

When a `@Query`/`@Mutation`/`@Subscription` has no explicit `output` schema, the CLI generator now infers the procedure's output type from the resolver method's return type, instead of falling back to `any`. This brings nestjs-trpc closer to native tRPC ergonomics and removes the need to duplicate service return types as decorator schemas.

## Approach

The generated file imports the router class with `import type` and casts the placeholder resolver to `Awaited<ReturnType<RouterClass["method"]>>`:

```ts
import type { FolderRouter } from "<...>/folder.router";

list: publicProcedure
  .query(async () => "PLACEHOLDER_DO_NOT_REMOVE" as unknown as Awaited<ReturnType<FolderRouter["list"]>>)
```

Inference is deferred to the consumer's `tsc`, so it works through arbitrary business logic and resolves referenced types transitively — the CLI never needs to be a type checker. `import type` is fully erased, so there's no runtime/bundle impact.

## Behavior

- **Explicit `output` schema always wins** — existing behavior is unchanged when `output` is provided.
- **Inference applies only to named-export routers.** Non-exported and default-exported routers fall back to `any`, since they can't be referenced by name from the generated file.
- **Runtime is unchanged** — tRPC already infers output natively at runtime when `.output()` is omitted; this only closes the codegen gap for the generated `AppRouter` type.

## Tests

- New `output-inference` fixture + snapshot covering inferred, explicit-override, and object-literal-return cases.
- A validation test runs `tsc` over the generated file to prove the `ReturnType<>` references compile and types flow through correctly.
- `non-exported-router` fixture asserts the `any` fallback.
- The validation harness now stubs bare-package modules (e.g. `nestjs-trpc`) imported by the router files that are now type-checked transitively.

All CLI tests pass; clippy (`-D warnings`) and rustfmt are clean.