### PR TITLE
ci: open a changelog PR instead of pushing to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -168,14 +169,20 @@ jobs:
             release-assets/nestjs-trpc-windows-x64.exe
             release-assets/checksums.txt
 
-      - name: Commit changelog to main
+      # main's branch ruleset (required status checks) declines a direct push, so the
+      # regenerated changelog is proposed as a PR instead of committed straight to main.
+      - name: Open changelog PR
         if: ${{ github.event_name == 'push' || !inputs.dry_run }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout main
-          git add CHANGELOG.md
-          git diff --cached --quiet && exit 0
-          git commit -m "chore(release): update changelog for v${{ steps.version.outputs.version }}"
-          git push origin main
+        uses: peter-evans/create-pull-request@v7
+        with:
+          base: main
+          branch: changelog/v${{ steps.version.outputs.version }}
+          add-paths: CHANGELOG.md
+          commit-message: "chore(release): update changelog for v${{ steps.version.outputs.version }}"
+          title: "chore(release): update changelog for v${{ steps.version.outputs.version }}"
+          body: |
+            Automated changelog update for the **v${{ steps.version.outputs.version }}** release.
+
+            Opened by the release workflow because `main`'s ruleset doesn't allow a direct push.
+          delete-branch: true
 


### PR DESCRIPTION
## Problem

The release workflow succeeds at the important steps — **publish to npm** and **create the GitHub Release** — but then tries to commit the regenerated `CHANGELOG.md` directly to `main`. `main`'s branch ruleset declines that push:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - 2 of 2 required status checks are expected.
! [remote rejected] main -> main (push declined due to repository rule violations)
```

So otherwise-successful releases (v2.10.0, v2.11.0) get marked **failed** on the very last step, after the package is already live.

## Fix

Instead of pushing to `main`, **open a PR** with the changelog change using `peter-evans/create-pull-request` (branch `changelog/v<version>`, scoped to `CHANGELOG.md`). This respects the ruleset, keeps the release job green, and still lands the changelog on `main` once the PR's checks pass and it's merged.

Also adds `pull-requests: write` to the `publish` job permissions.

## ⚠️ One-time repo setting required

For the workflow's `GITHUB_TOKEN` to open PRs, enable:

**Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"**

Without it, the step will fail with a 403.