### PR TITLE
feat: add Node.js ESM support via --add-js-extension flag for NestJS 12 compatibility

### DIFF
--- a/docs/pages/docs/index.mdx
+++ b/docs/pages/docs/index.mdx
@@ -107,6 +107,12 @@ By default, types are generated to `./src/@generated/server.ts`. You can customi
 npx nestjs-trpc generate --output ./src/trpc/types.ts
 ```
 
+For projects using `"moduleResolution": "NodeNext"` in tsconfig.json, import
+extensions are added automatically. Override with `--import-extension js|none|auto`:
+```bash copy
+npx nestjs-trpc generate --import-extension none
+```
+
 ### Start your NestJS server. You should be good to go! 🎉
 
 </Steps>

--- a/docs/pages/docs/index.mdx
+++ b/docs/pages/docs/index.mdx
@@ -107,11 +107,21 @@ By default, types are generated to `./src/@generated/server.ts`. You can customi
 npx nestjs-trpc generate --output ./src/trpc/types.ts
 ```
 
-For projects using `"moduleResolution": "NodeNext"` in tsconfig.json, import
-extensions are added automatically. Override with `--import-extension js|none|auto`:
+For projects using `"moduleResolution": "NodeNext"` or `"Node16"` in tsconfig.json, `.js`
+extensions are added automatically. The CLI searches the nearest `tsconfig.json` walking up
+from your source directory, so it works correctly whether you run from the project root or a
+subdirectory. Override with `--import-extension js|none|auto`:
 ```bash copy
 npx nestjs-trpc generate --import-extension none
 ```
+
+<Callout type="info">
+  **Note:** If your project uses `moduleResolution: bundler` (e.g. with Vite or esbuild) but
+  runs on plain Node ESM at runtime, `auto` will report `false` because bundler mode does not
+  require explicit file extensions at compile time. Use `--import-extension=js` explicitly in
+  that case.
+</Callout>
+
 
 ### Start your NestJS server. You should be good to go! 🎉
 

--- a/packages/nestjs-trpc/.gitignore
+++ b/packages/nestjs-trpc/.gitignore
@@ -9,10 +9,6 @@ node_modules
 /.awcache
 /.vscode
 
-/cli/benches/fixtures
-/cli/src/@generated
-/lib
-
 # misc
 npm-debug.log
 .DS_Store

--- a/packages/nestjs-trpc/.gitignore
+++ b/packages/nestjs-trpc/.gitignore
@@ -9,6 +9,10 @@ node_modules
 /.awcache
 /.vscode
 
+/cli/benches/fixtures
+/cli/src/@generated
+/lib
+
 # misc
 npm-debug.log
 .DS_Store

--- a/packages/nestjs-trpc/cli/Cargo.lock
+++ b/packages/nestjs-trpc/cli/Cargo.lock
@@ -967,6 +967,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonc-parser"
+version = "0.32.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "840785e1a8b4fdb27be18440a35a81af64820dc185c3973ff8b012d4c6282512"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,6 +1106,7 @@ dependencies = [
  "globset",
  "indicatif",
  "insta",
+ "jsonc-parser",
  "miette",
  "notify",
  "notify-debouncer-mini",

--- a/packages/nestjs-trpc/cli/Cargo.toml
+++ b/packages/nestjs-trpc/cli/Cargo.toml
@@ -57,9 +57,10 @@ anyhow = "1.0"
 thiserror = "2.0"
 miette = { version = "7.6", features = ["fancy"] }
 
-# JSON parsing
+# JSON / JSONC parsing
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+jsonc-parser = { version = "0.32", features = ["serde"] }
 
 # Text diffing (for dry-run mode)
 similar = "2.6"

--- a/packages/nestjs-trpc/cli/src/cli/generate.rs
+++ b/packages/nestjs-trpc/cli/src/cli/generate.rs
@@ -24,6 +24,7 @@ pub fn run_generate(
     router_pattern_override: Option<&str>,
     dry_run: bool,
     json_output: bool,
+    add_js_extension: bool,
 ) -> Result<ExitCode> {
     let current_directory = std::env::current_dir().context("Failed to get current directory")?;
 
@@ -59,6 +60,7 @@ pub fn run_generate(
             &router_pattern,
             json_output,
             transformer.as_ref(),
+            add_js_extension,
         )
     } else {
         run_normal_generation(
@@ -66,6 +68,7 @@ pub fn run_generate(
             &output_path,
             &router_pattern,
             transformer.as_ref(),
+            add_js_extension,
         )
     }
 }
@@ -83,9 +86,15 @@ fn run_normal_generation(
     output_path: &std::path::Path,
     router_pattern: &str,
     transformer: Option<&TransformerInfo>,
+    add_js_extension: bool,
 ) -> Result<ExitCode> {
-    let generation_result =
-        nestjs_trpc::run_generation(base_directory, output_path, router_pattern, transformer)?;
+    let generation_result = nestjs_trpc::run_generation(
+        base_directory,
+        output_path,
+        router_pattern,
+        transformer,
+        add_js_extension,
+    )?;
 
     print_summary(
         output_path,
@@ -101,6 +110,7 @@ fn run_dry_run_generation(
     router_pattern: &str,
     json_output: bool,
     transformer: Option<&TransformerInfo>,
+    add_js_extension: bool,
 ) -> Result<ExitCode> {
     let temp_directory = tempfile::tempdir().context("Failed to create temporary directory")?;
     let temp_output_path = temp_directory.path().join("@generated");
@@ -110,6 +120,7 @@ fn run_dry_run_generation(
         &temp_output_path,
         router_pattern,
         transformer,
+        add_js_extension,
     )?;
 
     let generated_server_path = temp_output_path.join("server.ts");

--- a/packages/nestjs-trpc/cli/src/cli/generate.rs
+++ b/packages/nestjs-trpc/cli/src/cli/generate.rs
@@ -24,7 +24,7 @@ pub fn run_generate(
     router_pattern_override: Option<&str>,
     dry_run: bool,
     json_output: bool,
-    add_js_extension: bool,
+    import_extension: bool,
 ) -> Result<ExitCode> {
     let current_directory = std::env::current_dir().context("Failed to get current directory")?;
 
@@ -60,7 +60,7 @@ pub fn run_generate(
             &router_pattern,
             json_output,
             transformer.as_ref(),
-            add_js_extension,
+            import_extension,
         )
     } else {
         run_normal_generation(
@@ -68,7 +68,7 @@ pub fn run_generate(
             &output_path,
             &router_pattern,
             transformer.as_ref(),
-            add_js_extension,
+            import_extension,
         )
     }
 }
@@ -86,14 +86,14 @@ fn run_normal_generation(
     output_path: &std::path::Path,
     router_pattern: &str,
     transformer: Option<&TransformerInfo>,
-    add_js_extension: bool,
+    import_extension: bool,
 ) -> Result<ExitCode> {
     let generation_result = nestjs_trpc::run_generation(
         base_directory,
         output_path,
         router_pattern,
         transformer,
-        add_js_extension,
+        import_extension,
     )?;
 
     print_summary(
@@ -110,7 +110,7 @@ fn run_dry_run_generation(
     router_pattern: &str,
     json_output: bool,
     transformer: Option<&TransformerInfo>,
-    add_js_extension: bool,
+    import_extension: bool,
 ) -> Result<ExitCode> {
     let temp_directory = tempfile::tempdir().context("Failed to create temporary directory")?;
     let temp_output_path = temp_directory.path().join("@generated");
@@ -120,7 +120,7 @@ fn run_dry_run_generation(
         &temp_output_path,
         router_pattern,
         transformer,
-        add_js_extension,
+        import_extension,
     )?;
 
     let generated_server_path = temp_output_path.join("server.ts");

--- a/packages/nestjs-trpc/cli/src/cli/generate.rs
+++ b/packages/nestjs-trpc/cli/src/cli/generate.rs
@@ -7,16 +7,29 @@ use console::style;
 use tracing::info;
 
 use nestjs_trpc::{
-    compute_diff, discover_root_module, extract_trpc_options, find_tsc, resolve_transformer_import,
-    run_tsc_validation, DiffResult, TransformerInfo, TsParser,
+    compute_diff, config, discover_root_module, extract_trpc_options, find_tsc,
+    resolve_transformer_import, run_tsc_validation, DiffResult, TransformerInfo, TsParser,
 };
 
 use super::output::{DiffSummary, DryRunOutput, ValidationError};
-use super::{DEFAULT_OUTPUT_PATH, DEFAULT_ROUTER_PATTERN};
+use super::{ImportExtensionValue, DEFAULT_OUTPUT_PATH, DEFAULT_ROUTER_PATTERN};
 
 const MAX_ERRORS_DISPLAYED: usize = 10;
 const EXIT_SUCCESS: u8 = 0;
 const EXIT_VALIDATION_ERROR: u8 = 1;
+
+fn resolve_import_extension(
+    value: Option<&ImportExtensionValue>,
+    base_directory: &std::path::Path,
+) -> bool {
+    match value {
+        Some(ImportExtensionValue::Js) => true,
+        Some(ImportExtensionValue::None) => false,
+        Some(ImportExtensionValue::Auto) | None => {
+            config::detect_import_extension(base_directory).unwrap_or(false)
+        }
+    }
+}
 
 pub fn run_generate(
     entrypoint_override: Option<&str>,
@@ -24,7 +37,7 @@ pub fn run_generate(
     router_pattern_override: Option<&str>,
     dry_run: bool,
     json_output: bool,
-    import_extension: bool,
+    import_extension: Option<&ImportExtensionValue>,
 ) -> Result<ExitCode> {
     let current_directory = std::env::current_dir().context("Failed to get current directory")?;
 
@@ -51,6 +64,7 @@ pub fn run_generate(
 
     let base_directory = root_module_path.parent().unwrap_or(&current_directory);
 
+    let should_add_js = resolve_import_extension(import_extension, base_directory);
     let transformer = extract_transformer_from_module(&root_module_path);
 
     if dry_run {
@@ -60,7 +74,7 @@ pub fn run_generate(
             &router_pattern,
             json_output,
             transformer.as_ref(),
-            import_extension,
+            should_add_js,
         )
     } else {
         run_normal_generation(
@@ -68,7 +82,7 @@ pub fn run_generate(
             &output_path,
             &router_pattern,
             transformer.as_ref(),
-            import_extension,
+            should_add_js,
         )
     }
 }

--- a/packages/nestjs-trpc/cli/src/cli/mod.rs
+++ b/packages/nestjs-trpc/cli/src/cli/mod.rs
@@ -5,10 +5,17 @@ mod watch;
 pub use generate::run_generate;
 pub use watch::run_watch;
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 
 pub const DEFAULT_ROUTER_PATTERN: &str = "**/*.router.ts";
 pub const DEFAULT_OUTPUT_PATH: &str = "./src/@generated";
+
+#[derive(ValueEnum, Clone, Debug)]
+pub enum ImportExtensionValue {
+    Js,
+    None,
+    Auto,
+}
 
 #[derive(Parser, Debug)]
 #[command(name = "nestjs-trpc")]
@@ -63,9 +70,9 @@ pub enum Commands {
         #[arg(long, help_heading = "Validation")]
         dry_run: bool,
 
-        /// Add .js extension to local import paths for ESM compatibility (NodeNext)
-        #[arg(long = "add-js-extension", help_heading = "Output")]
-        add_js_extension: bool,
+        /// Add .js extension to local import paths (js|none|auto) [default: auto]
+        #[arg(long = "import-extension", value_enum, help_heading = "Output")]
+        import_extension: Option<ImportExtensionValue>,
     },
     /// Watch for file changes and regenerate router types automatically
     #[command(after_help = "EXAMPLES:
@@ -85,8 +92,8 @@ pub enum Commands {
         #[arg(short, long, value_name = "PATH", help_heading = "Output")]
         output: Option<String>,
 
-        /// Add .js extension to local import paths for ESM compatibility (NodeNext)
-        #[arg(long = "add-js-extension", help_heading = "Output")]
-        add_js_extension: bool,
+        /// Add .js extension to local import paths (js|none|auto) [default: auto]
+        #[arg(long = "import-extension", value_enum, help_heading = "Output")]
+        import_extension: Option<ImportExtensionValue>,
     },
 }

--- a/packages/nestjs-trpc/cli/src/cli/mod.rs
+++ b/packages/nestjs-trpc/cli/src/cli/mod.rs
@@ -62,6 +62,10 @@ pub enum Commands {
         /// Validate and show what would be generated without writing files
         #[arg(long, help_heading = "Validation")]
         dry_run: bool,
+
+        /// Add .js extension to local import paths for ESM compatibility (NodeNext)
+        #[arg(long = "add-js-extension", help_heading = "Output")]
+        add_js_extension: bool,
     },
     /// Watch for file changes and regenerate router types automatically
     #[command(after_help = "EXAMPLES:
@@ -80,5 +84,9 @@ pub enum Commands {
         /// Output directory for generated files
         #[arg(short, long, value_name = "PATH", help_heading = "Output")]
         output: Option<String>,
+
+        /// Add .js extension to local import paths for ESM compatibility (NodeNext)
+        #[arg(long = "add-js-extension", help_heading = "Output")]
+        add_js_extension: bool,
     },
 }

--- a/packages/nestjs-trpc/cli/src/cli/mod.rs
+++ b/packages/nestjs-trpc/cli/src/cli/mod.rs
@@ -70,7 +70,16 @@ pub enum Commands {
         #[arg(long, help_heading = "Validation")]
         dry_run: bool,
 
-        /// Add .js extension to local import paths (js|none|auto) [default: auto]
+        /// Add .js extension to local import paths
+        ///
+        /// `auto` (default) reads the nearest tsconfig.json and enables .js
+        /// when `module` or `moduleResolution` is NodeNext/Node16.
+        ///
+        /// **Note:** projects using `moduleResolution: bundler` (e.g.
+        /// `module: ESNext + moduleResolution: bundler`) but running on plain
+        /// Node ESM still need .js extensions at runtime. `auto` will report
+        /// `false` in that case because bundler mode does not require explicit
+        /// extensions at compile time — use `--import-extension=js` explicitly.
         #[arg(long = "import-extension", value_enum, help_heading = "Output")]
         import_extension: Option<ImportExtensionValue>,
     },
@@ -92,7 +101,14 @@ pub enum Commands {
         #[arg(short, long, value_name = "PATH", help_heading = "Output")]
         output: Option<String>,
 
-        /// Add .js extension to local import paths (js|none|auto) [default: auto]
+        /// Add .js extension to local import paths
+        ///
+        /// `auto` (default) reads the nearest tsconfig.json and enables .js
+        /// when `module` or `moduleResolution` is NodeNext/Node16.
+        ///
+        /// **Note:** projects using `moduleResolution: bundler` but running on
+        /// plain Node ESM still need .js extensions at runtime — use
+        /// `--import-extension=js` explicitly in that case.
         #[arg(long = "import-extension", value_enum, help_heading = "Output")]
         import_extension: Option<ImportExtensionValue>,
     },

--- a/packages/nestjs-trpc/cli/src/cli/watch.rs
+++ b/packages/nestjs-trpc/cli/src/cli/watch.rs
@@ -15,7 +15,7 @@ pub fn run_watch(
     output_override: Option<&str>,
     router_pattern_override: Option<&str>,
     verbose: bool,
-    add_js_extension: bool,
+    import_extension: bool,
 ) -> Result<()> {
     let current_directory = std::env::current_dir().context("Failed to get current directory")?;
 
@@ -57,7 +57,7 @@ pub fn run_watch(
         .with_debounce_milliseconds(300)
         .with_verbose(verbose)
         .with_transformer(transformer)
-        .with_add_js_extension(add_js_extension);
+        .with_import_extension(import_extension);
 
     let session = WatchSession::new(config)?;
     session.run()

--- a/packages/nestjs-trpc/cli/src/cli/watch.rs
+++ b/packages/nestjs-trpc/cli/src/cli/watch.rs
@@ -4,18 +4,31 @@ use anyhow::{Context, Result};
 use tracing::{debug, info};
 
 use nestjs_trpc::{
-    discover_root_module, extract_trpc_options, resolve_transformer_import, TsParser, WatchConfig,
-    WatchSession,
+    config, discover_root_module, extract_trpc_options, resolve_transformer_import, TsParser,
+    WatchConfig, WatchSession,
 };
 
-use super::{DEFAULT_OUTPUT_PATH, DEFAULT_ROUTER_PATTERN};
+use super::{ImportExtensionValue, DEFAULT_OUTPUT_PATH, DEFAULT_ROUTER_PATTERN};
+
+fn resolve_import_extension(
+    value: Option<&ImportExtensionValue>,
+    base_directory: &std::path::Path,
+) -> bool {
+    match value {
+        Some(ImportExtensionValue::Js) => true,
+        Some(ImportExtensionValue::None) => false,
+        Some(ImportExtensionValue::Auto) | None => {
+            config::detect_import_extension(base_directory).unwrap_or(false)
+        }
+    }
+}
 
 pub fn run_watch(
     entrypoint_override: Option<&str>,
     output_override: Option<&str>,
     router_pattern_override: Option<&str>,
     verbose: bool,
-    import_extension: bool,
+    import_extension: Option<&ImportExtensionValue>,
 ) -> Result<()> {
     let current_directory = std::env::current_dir().context("Failed to get current directory")?;
 
@@ -44,6 +57,8 @@ pub fn run_watch(
 
     let base_directory = root_module_path.parent().unwrap_or(&current_directory);
 
+    let should_add_js = resolve_import_extension(import_extension, base_directory);
+
     debug!(
         output_path = %output_path.display(),
         router_pattern = %router_pattern,
@@ -57,7 +72,7 @@ pub fn run_watch(
         .with_debounce_milliseconds(300)
         .with_verbose(verbose)
         .with_transformer(transformer)
-        .with_import_extension(import_extension);
+        .with_import_extension(should_add_js);
 
     let session = WatchSession::new(config)?;
     session.run()

--- a/packages/nestjs-trpc/cli/src/cli/watch.rs
+++ b/packages/nestjs-trpc/cli/src/cli/watch.rs
@@ -15,6 +15,7 @@ pub fn run_watch(
     output_override: Option<&str>,
     router_pattern_override: Option<&str>,
     verbose: bool,
+    add_js_extension: bool,
 ) -> Result<()> {
     let current_directory = std::env::current_dir().context("Failed to get current directory")?;
 
@@ -55,7 +56,8 @@ pub fn run_watch(
     let config = WatchConfig::new(router_pattern, output_path, base_directory.to_path_buf())
         .with_debounce_milliseconds(300)
         .with_verbose(verbose)
-        .with_transformer(transformer);
+        .with_transformer(transformer)
+        .with_add_js_extension(add_js_extension);
 
     let session = WatchSession::new(config)?;
     session.run()

--- a/packages/nestjs-trpc/cli/src/config.rs
+++ b/packages/nestjs-trpc/cli/src/config.rs
@@ -652,6 +652,36 @@ export default {
     }
 
     #[test]
+    fn test_detect_import_extension_from_subdirectory() {
+        // Mirrors the most common real-world layout: tsconfig.json at the
+        // project root, source files under src/.  The CLI derives
+        // base_directory from root_module_path.parent(), which is `src/` —
+        // detect_import_extension must still find the parent tsconfig.
+        let temporary_directory = TempDir::new().unwrap();
+        let root = temporary_directory.path();
+
+        let tsconfig = serde_json::json!({
+            "compilerOptions": {
+                "module": "NodeNext",
+                "moduleResolution": "NodeNext"
+            }
+        });
+        fs::write(
+            root.join("tsconfig.json"),
+            serde_json::to_string_pretty(&tsconfig).unwrap(),
+        )
+        .unwrap();
+
+        // Source lives one level deeper — no tsconfig here.
+        let src = root.join("src");
+        fs::create_dir_all(&src).unwrap();
+
+        // Called with `src/` as the base, not the root.
+        let result = detect_import_extension(&src);
+        assert_eq!(result, Some(true));
+    }
+
+    #[test]
     fn test_detect_import_extension_invalid_json() {
         let temporary_directory = TempDir::new().unwrap();
         let base = temporary_directory.path();

--- a/packages/nestjs-trpc/cli/src/config.rs
+++ b/packages/nestjs-trpc/cli/src/config.rs
@@ -1,11 +1,12 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use serde_json::Value;
 use swc_ecma_ast::{
     ExportDefaultExpr, Expr, ExprOrSpread, Lit, ModuleDecl, ModuleItem, ObjectLit, Prop, PropName,
     PropOrSpread,
 };
-use tracing::trace;
+use tracing::{debug, trace};
 
 use crate::error::ConfigError;
 use crate::parser::TsParser;
@@ -337,9 +338,40 @@ impl Config {
     }
 }
 
+/// Detects whether `.js` extensions should be added to local import paths
+/// by resolving the full `extends` chain and inspecting the merged
+/// `compilerOptions.module` and `compilerOptions.moduleResolution`.
+///
+/// Returns `Some(true)` for `NodeNext`/`Node16` (which require `.js` extensions),
+/// `Some(false)` for other settings,
+/// `None` if no tsconfig exists.
+#[must_use]
+pub fn detect_import_extension(base_directory: &Path) -> Option<bool> {
+    let options = crate::tsconfig::resolve_compiler_options(base_directory)?;
+
+    let module_resolution = options.get("moduleResolution").and_then(Value::as_str);
+    let module = options.get("module").and_then(Value::as_str);
+
+    let requires_extension = module_resolution.is_some_and(|value| {
+        value.eq_ignore_ascii_case("NodeNext") || value.eq_ignore_ascii_case("Node16")
+    }) || module.is_some_and(|value| {
+        value.eq_ignore_ascii_case("NodeNext") || value.eq_ignore_ascii_case("Node16")
+    });
+
+    debug!(
+        module_resolution = module_resolution,
+        module = module,
+        requires_extension = requires_extension,
+        "Determined import extension requirement from resolved tsconfig"
+    );
+
+    Some(requires_extension)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
 
     #[test]
     fn test_parse_full_config() {
@@ -469,6 +501,232 @@ export default {
             }
             _ => panic!("Expected InvalidSyntax error for unknown field"),
         }
+    }
+
+    #[test]
+    fn test_detect_import_extension_node_next() {
+        let temporary_directory = TempDir::new().unwrap();
+        let base = temporary_directory.path();
+
+        let tsconfig = serde_json::json!({
+            "compilerOptions": {
+                "module": "NodeNext",
+                "moduleResolution": "NodeNext"
+            }
+        });
+        fs::write(
+            base.join("tsconfig.json"),
+            serde_json::to_string_pretty(&tsconfig).unwrap(),
+        )
+        .unwrap();
+
+        let result = detect_import_extension(base);
+        assert_eq!(result, Some(true));
+    }
+
+    #[test]
+    fn test_detect_import_extension_node16() {
+        let temporary_directory = TempDir::new().unwrap();
+        let base = temporary_directory.path();
+
+        let tsconfig = serde_json::json!({
+            "compilerOptions": {
+                "module": "Node16",
+                "moduleResolution": "Node16"
+            }
+        });
+        fs::write(
+            base.join("tsconfig.json"),
+            serde_json::to_string_pretty(&tsconfig).unwrap(),
+        )
+        .unwrap();
+
+        let result = detect_import_extension(base);
+        assert_eq!(result, Some(true));
+    }
+
+    #[test]
+    fn test_js_node16_module_implies_resolution() {
+        let temporary_directory = TempDir::new().unwrap();
+        let base = temporary_directory.path();
+
+        let tsconfig = serde_json::json!({
+            "compilerOptions": {
+                "module": "Node16"
+            }
+        });
+        fs::write(
+            base.join("tsconfig.json"),
+            serde_json::to_string_pretty(&tsconfig).unwrap(),
+        )
+        .unwrap();
+
+        let result = detect_import_extension(base);
+        assert_eq!(result, Some(true));
+    }
+
+    #[test]
+    fn test_detect_import_extension_bundler() {
+        let temporary_directory = TempDir::new().unwrap();
+        let base = temporary_directory.path();
+
+        let tsconfig = serde_json::json!({
+            "compilerOptions": {
+                "moduleResolution": "bundler"
+            }
+        });
+        fs::write(
+            base.join("tsconfig.json"),
+            serde_json::to_string_pretty(&tsconfig).unwrap(),
+        )
+        .unwrap();
+
+        let result = detect_import_extension(base);
+        assert_eq!(result, Some(false));
+    }
+
+    #[test]
+    fn test_detect_import_extension_esnext() {
+        let temporary_directory = TempDir::new().unwrap();
+        let base = temporary_directory.path();
+
+        let tsconfig = serde_json::json!({
+            "compilerOptions": {
+                "module": "ESNext",
+                "moduleResolution": "bundler"
+            }
+        });
+        fs::write(
+            base.join("tsconfig.json"),
+            serde_json::to_string_pretty(&tsconfig).unwrap(),
+        )
+        .unwrap();
+
+        let result = detect_import_extension(base);
+        assert_eq!(result, Some(false));
+    }
+
+    #[test]
+    fn test_detect_import_extension_missing_field() {
+        let temporary_directory = TempDir::new().unwrap();
+        let base = temporary_directory.path();
+
+        let tsconfig = serde_json::json!({
+            "compilerOptions": {}
+        });
+        fs::write(
+            base.join("tsconfig.json"),
+            serde_json::to_string_pretty(&tsconfig).unwrap(),
+        )
+        .unwrap();
+
+        let result = detect_import_extension(base);
+        assert_eq!(result, Some(false));
+    }
+
+    #[test]
+    fn test_detect_import_extension_no_tsconfig() {
+        let temporary_directory = TempDir::new().unwrap();
+        let base = temporary_directory.path();
+
+        let result = detect_import_extension(base);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_jsonc_comments_and_trailing_commas() {
+        let temporary_directory = TempDir::new().unwrap();
+        let base = temporary_directory.path();
+
+        let tsconfig = r#"{
+            // comment
+            "compilerOptions": {
+                "module": "NodeNext",
+                "moduleResolution": "NodeNext", // trailing comma
+            },
+        }"#;
+        fs::write(base.join("tsconfig.json"), tsconfig).unwrap();
+
+        let result = detect_import_extension(base);
+        assert_eq!(result, Some(true));
+    }
+
+    #[test]
+    fn test_detect_import_extension_invalid_json() {
+        let temporary_directory = TempDir::new().unwrap();
+        let base = temporary_directory.path();
+
+        fs::write(base.join("tsconfig.json"), "not valid json").unwrap();
+
+        let result = detect_import_extension(base);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_extends_chain_inherits_module() {
+        let temporary_directory = TempDir::new().unwrap();
+        let base = temporary_directory.path();
+
+        let parent = serde_json::json!({
+            "compilerOptions": {
+                "module": "NodeNext",
+                "moduleResolution": "NodeNext"
+            }
+        });
+        fs::write(
+            base.join("tsconfig.base.json"),
+            serde_json::to_string_pretty(&parent).unwrap(),
+        )
+        .unwrap();
+
+        let child = serde_json::json!({
+            "extends": "./tsconfig.base.json",
+            "compilerOptions": {
+                "outDir": "./dist"
+            }
+        });
+        fs::write(
+            base.join("tsconfig.json"),
+            serde_json::to_string_pretty(&child).unwrap(),
+        )
+        .unwrap();
+
+        let result = detect_import_extension(base);
+        assert_eq!(result, Some(true));
+    }
+
+    #[test]
+    fn test_extends_chain_child_overrides_to_not_require() {
+        let temporary_directory = TempDir::new().unwrap();
+        let base = temporary_directory.path();
+
+        let parent = serde_json::json!({
+            "compilerOptions": {
+                "module": "NodeNext",
+                "moduleResolution": "NodeNext"
+            }
+        });
+        fs::write(
+            base.join("tsconfig.base.json"),
+            serde_json::to_string_pretty(&parent).unwrap(),
+        )
+        .unwrap();
+
+        let child = serde_json::json!({
+            "extends": "./tsconfig.base.json",
+            "compilerOptions": {
+                "module": "ESNext",
+                "moduleResolution": "bundler"
+            }
+        });
+        fs::write(
+            base.join("tsconfig.json"),
+            serde_json::to_string_pretty(&child).unwrap(),
+        )
+        .unwrap();
+
+        let result = detect_import_extension(base);
+        assert_eq!(result, Some(false));
     }
 
     #[test]

--- a/packages/nestjs-trpc/cli/src/generation.rs
+++ b/packages/nestjs-trpc/cli/src/generation.rs
@@ -32,6 +32,7 @@ pub fn run_generation(
     output_path: &Path,
     router_pattern: &str,
     transformer: Option<&TransformerInfo>,
+    add_js_extension: bool,
 ) -> Result<GenerationResult> {
     let start_time = Instant::now();
 
@@ -47,7 +48,7 @@ pub fn run_generation(
         &parsed_files,
         base_directory,
     );
-    write_server_file(output_path, &routers, &schema_locations, transformer)?;
+    write_server_file(output_path, &routers, &schema_locations, transformer, add_js_extension)?;
 
     let router_count = routers.len();
     let procedure_count = routers.iter().map(|r| r.procedures.len()).sum();
@@ -542,8 +543,11 @@ fn write_server_file(
     routers: &[RouterMetadata],
     schema_locations: &HashMap<String, PathBuf>,
     transformer: Option<&TransformerInfo>,
+    add_js_extension: bool,
 ) -> Result<PathBuf> {
-    let static_generator = StaticGenerator::new().with_transformer(transformer.cloned());
+    let static_generator = StaticGenerator::new()
+        .with_transformer(transformer.cloned())
+        .with_add_js_extension(add_js_extension);
     let server_generator = ServerGenerator::new().with_static_generator(static_generator);
 
     let server_file_path = if output_path

--- a/packages/nestjs-trpc/cli/src/generation.rs
+++ b/packages/nestjs-trpc/cli/src/generation.rs
@@ -32,7 +32,7 @@ pub fn run_generation(
     output_path: &Path,
     router_pattern: &str,
     transformer: Option<&TransformerInfo>,
-    add_js_extension: bool,
+    import_extension: bool,
 ) -> Result<GenerationResult> {
     let start_time = Instant::now();
 
@@ -48,7 +48,13 @@ pub fn run_generation(
         &parsed_files,
         base_directory,
     );
-    write_server_file(output_path, &routers, &schema_locations, transformer, add_js_extension)?;
+    write_server_file(
+        output_path,
+        &routers,
+        &schema_locations,
+        transformer,
+        import_extension,
+    )?;
 
     let router_count = routers.len();
     let procedure_count = routers.iter().map(|r| r.procedures.len()).sum();
@@ -543,11 +549,11 @@ fn write_server_file(
     routers: &[RouterMetadata],
     schema_locations: &HashMap<String, PathBuf>,
     transformer: Option<&TransformerInfo>,
-    add_js_extension: bool,
+    import_extension: bool,
 ) -> Result<PathBuf> {
     let static_generator = StaticGenerator::new()
         .with_transformer(transformer.cloned())
-        .with_add_js_extension(add_js_extension);
+        .with_import_extension(import_extension);
     let server_generator = ServerGenerator::new().with_static_generator(static_generator);
 
     let server_file_path = if output_path

--- a/packages/nestjs-trpc/cli/src/generator/mod.rs
+++ b/packages/nestjs-trpc/cli/src/generator/mod.rs
@@ -18,6 +18,8 @@ pub struct StaticGenerator {
 
     pub(crate) use_semicolons: bool,
 
+    pub(crate) add_js_extension: bool,
+
     pub(crate) transformer: Option<TransformerInfo>,
 }
 
@@ -33,6 +35,7 @@ impl StaticGenerator {
         Self {
             use_single_quotes: false,
             use_semicolons: true,
+            add_js_extension: false,
             transformer: None,
         }
     }
@@ -46,6 +49,12 @@ impl StaticGenerator {
     #[must_use]
     pub const fn with_semicolons(mut self, use_semicolons: bool) -> Self {
         self.use_semicolons = use_semicolons;
+        self
+    }
+
+    #[must_use]
+    pub const fn with_add_js_extension(mut self, add_js_extension: bool) -> Self {
+        self.add_js_extension = add_js_extension;
         self
     }
 
@@ -189,6 +198,7 @@ impl StaticGenerator {
             &mut seen_names,
             &mut path_order,
             &mut names_by_path,
+            self.add_js_extension,
         );
 
         let q = self.quote();
@@ -206,7 +216,7 @@ impl StaticGenerator {
             .collect()
     }
 
-    fn calculate_relative_path(from_dir: &Path, to_file: &Path) -> String {
+    fn calculate_relative_path(from_dir: &Path, to_file: &Path, add_js_extension: bool) -> String {
         let relative = pathdiff::diff_paths(to_file, from_dir).map_or_else(
             || to_file.to_string_lossy().to_string(),
             |p| p.to_string_lossy().to_string(),
@@ -220,10 +230,16 @@ impl StaticGenerator {
             .or_else(|| relative.strip_suffix(".tsx"))
             .unwrap_or(&relative);
 
-        if without_ext.starts_with('.') || without_ext.starts_with('/') {
-            without_ext.to_string()
+        let normalized_path = if add_js_extension {
+            format!("{without_ext}.js")
         } else {
-            format!("./{without_ext}")
+            without_ext.to_string()
+        };
+
+        if normalized_path.starts_with('.') || normalized_path.starts_with('/') {
+            normalized_path
+        } else {
+            format!("./{normalized_path}")
         }
     }
 }
@@ -235,6 +251,7 @@ fn group_schema_names_by_path<'a, I>(
     seen_names: &mut HashSet<&'a str>,
     path_order: &mut Vec<String>,
     names_by_path: &mut std::collections::HashMap<String, Vec<&'a str>>,
+    add_js_extension: bool,
 ) where
     I: IntoIterator<Item = &'a str>,
 {
@@ -245,7 +262,7 @@ fn group_schema_names_by_path<'a, I>(
         let Some(source_path) = schema_locations.get(name) else {
             continue;
         };
-        let import_path = resolve_import_path(output_dir, source_path);
+        let import_path = resolve_import_path(output_dir, source_path, add_js_extension);
         if !names_by_path.contains_key(&import_path) {
             path_order.push(import_path.clone());
         }
@@ -253,13 +270,13 @@ fn group_schema_names_by_path<'a, I>(
     }
 }
 
-fn resolve_import_path(output_dir: &Path, source_path: &Path) -> String {
+fn resolve_import_path(output_dir: &Path, source_path: &Path, add_js_extension: bool) -> String {
     let is_external_package = output_dir.is_absolute() && !source_path.is_absolute();
     if is_external_package {
         // Windows paths use backslashes which aren't valid in ES module import specifiers
         source_path.to_string_lossy().replace('\\', "/")
     } else {
-        StaticGenerator::calculate_relative_path(output_dir, source_path)
+        StaticGenerator::calculate_relative_path(output_dir, source_path, add_js_extension)
     }
 }
 
@@ -400,6 +417,7 @@ mod tests {
         let result = StaticGenerator::calculate_relative_path(
             Path::new("src/@generated"),
             Path::new("src/@generated/types.ts"),
+            false,
         );
         assert_eq!(result, "./types");
 
@@ -407,8 +425,26 @@ mod tests {
         let result = StaticGenerator::calculate_relative_path(
             Path::new("src/@generated"),
             Path::new("src/schemas/user.ts"),
+            false,
         );
         assert_eq!(result, "../schemas/user");
+    }
+
+    #[test]
+    fn test_calculate_relative_path_with_js_extension() {
+        let result = StaticGenerator::calculate_relative_path(
+            Path::new("src/@generated"),
+            Path::new("src/app.router.ts"),
+            true,
+        );
+        assert_eq!(result, "../app.router.js");
+
+        let result = StaticGenerator::calculate_relative_path(
+            Path::new("src/@generated"),
+            Path::new("src/folder.router.tsx"),
+            true,
+        );
+        assert_eq!(result, "../folder.router.js");
     }
 
     #[test]
@@ -419,7 +455,7 @@ mod tests {
         let output_directory = Path::new("/absolute/path");
         let source_path = Path::new("schemas\\user.schema");
 
-        let result = resolve_import_path(output_directory, source_path);
+        let result = resolve_import_path(output_directory, source_path, false);
 
         assert!(
             !result.contains('\\'),

--- a/packages/nestjs-trpc/cli/src/generator/mod.rs
+++ b/packages/nestjs-trpc/cli/src/generator/mod.rs
@@ -18,7 +18,7 @@ pub struct StaticGenerator {
 
     pub(crate) use_semicolons: bool,
 
-    pub(crate) add_js_extension: bool,
+    pub(crate) import_extension: bool,
 
     pub(crate) transformer: Option<TransformerInfo>,
 }
@@ -35,7 +35,7 @@ impl StaticGenerator {
         Self {
             use_single_quotes: false,
             use_semicolons: true,
-            add_js_extension: false,
+            import_extension: false,
             transformer: None,
         }
     }
@@ -53,8 +53,8 @@ impl StaticGenerator {
     }
 
     #[must_use]
-    pub const fn with_add_js_extension(mut self, add_js_extension: bool) -> Self {
-        self.add_js_extension = add_js_extension;
+    pub const fn with_import_extension(mut self, import_extension: bool) -> Self {
+        self.import_extension = import_extension;
         self
     }
 
@@ -198,7 +198,7 @@ impl StaticGenerator {
             &mut seen_names,
             &mut path_order,
             &mut names_by_path,
-            self.add_js_extension,
+            self.import_extension,
         );
 
         let q = self.quote();
@@ -216,7 +216,7 @@ impl StaticGenerator {
             .collect()
     }
 
-    fn calculate_relative_path(from_dir: &Path, to_file: &Path, add_js_extension: bool) -> String {
+    fn calculate_relative_path(from_dir: &Path, to_file: &Path, import_extension: bool) -> String {
         let relative = pathdiff::diff_paths(to_file, from_dir).map_or_else(
             || to_file.to_string_lossy().to_string(),
             |p| p.to_string_lossy().to_string(),
@@ -230,7 +230,7 @@ impl StaticGenerator {
             .or_else(|| relative.strip_suffix(".tsx"))
             .unwrap_or(&relative);
 
-        let normalized_path = if add_js_extension {
+        let normalized_path = if import_extension {
             format!("{without_ext}.js")
         } else {
             without_ext.to_string()
@@ -251,7 +251,7 @@ fn group_schema_names_by_path<'a, I>(
     seen_names: &mut HashSet<&'a str>,
     path_order: &mut Vec<String>,
     names_by_path: &mut std::collections::HashMap<String, Vec<&'a str>>,
-    add_js_extension: bool,
+    import_extension: bool,
 ) where
     I: IntoIterator<Item = &'a str>,
 {
@@ -262,7 +262,7 @@ fn group_schema_names_by_path<'a, I>(
         let Some(source_path) = schema_locations.get(name) else {
             continue;
         };
-        let import_path = resolve_import_path(output_dir, source_path, add_js_extension);
+        let import_path = resolve_import_path(output_dir, source_path, import_extension);
         if !names_by_path.contains_key(&import_path) {
             path_order.push(import_path.clone());
         }
@@ -270,13 +270,13 @@ fn group_schema_names_by_path<'a, I>(
     }
 }
 
-fn resolve_import_path(output_dir: &Path, source_path: &Path, add_js_extension: bool) -> String {
+fn resolve_import_path(output_dir: &Path, source_path: &Path, import_extension: bool) -> String {
     let is_external_package = output_dir.is_absolute() && !source_path.is_absolute();
     if is_external_package {
         // Windows paths use backslashes which aren't valid in ES module import specifiers
         source_path.to_string_lossy().replace('\\', "/")
     } else {
-        StaticGenerator::calculate_relative_path(output_dir, source_path, add_js_extension)
+        StaticGenerator::calculate_relative_path(output_dir, source_path, import_extension)
     }
 }
 
@@ -452,7 +452,12 @@ mod tests {
         // On Unix, backslash is a valid filename char so this creates a single component.
         // On Windows, it creates a two-component path. Either way, the output must use
         // forward slashes since backslashes aren't valid in ES module import specifiers.
+        // We need a platform-appropriate absolute path so is_external_package works correctly.
+        #[cfg(unix)]
         let output_directory = Path::new("/absolute/path");
+        #[cfg(windows)]
+        let output_directory = Path::new("C:\\absolute\\path");
+
         let source_path = Path::new("schemas\\user.schema");
 
         let result = resolve_import_path(output_directory, source_path, false);

--- a/packages/nestjs-trpc/cli/src/generator/server.rs
+++ b/packages/nestjs-trpc/cli/src/generator/server.rs
@@ -1416,4 +1416,29 @@ mod tests {
         assert!(output.contains("import type { FolderRouter } from \"./folder.router\";"));
         assert!(output.contains("Awaited<ReturnType<FolderRouter[\"list\"]>>"));
     }
+
+    #[test]
+    fn test_inferred_output_emits_router_type_import_with_js_extension() {
+        let static_generator = StaticGenerator::new().with_add_js_extension(true);
+        let generator = ServerGenerator::new().with_static_generator(static_generator);
+        let routers = vec![create_test_router(
+            "FolderRouter",
+            Some("folders"),
+            vec![create_inferred_procedure(
+                "list",
+                ProcedureType::Query,
+                "FolderRouter",
+                "folder.router.ts",
+            )],
+        )];
+
+        let output = generator.generate_with_schema_imports(
+            &routers,
+            &HashMap::new(),
+            Path::new("server.ts"),
+        );
+
+        assert!(output.contains("import type { FolderRouter } from \"./folder.router.js\";"));
+        assert!(output.contains("Awaited<ReturnType<FolderRouter[\"list\"]>>"));
+    }
 }

--- a/packages/nestjs-trpc/cli/src/generator/server.rs
+++ b/packages/nestjs-trpc/cli/src/generator/server.rs
@@ -1419,7 +1419,7 @@ mod tests {
 
     #[test]
     fn test_inferred_output_emits_router_type_import_with_js_extension() {
-        let static_generator = StaticGenerator::new().with_add_js_extension(true);
+        let static_generator = StaticGenerator::new().with_import_extension(true);
         let generator = ServerGenerator::new().with_static_generator(static_generator);
         let routers = vec![create_test_router(
             "FolderRouter",

--- a/packages/nestjs-trpc/cli/src/lib.rs
+++ b/packages/nestjs-trpc/cli/src/lib.rs
@@ -10,6 +10,7 @@ pub mod generation;
 pub mod generator;
 pub mod parser;
 pub mod scanner;
+pub mod tsconfig;
 pub mod validation;
 pub mod watcher;
 

--- a/packages/nestjs-trpc/cli/src/main.rs
+++ b/packages/nestjs-trpc/cli/src/main.rs
@@ -109,6 +109,7 @@ fn run(cli: &Cli) -> Result<ExitCode> {
             router_pattern,
             json,
             dry_run,
+            add_js_extension,
         }) => {
             return cli::run_generate(
                 entrypoint.as_deref(),
@@ -116,18 +117,21 @@ fn run(cli: &Cli) -> Result<ExitCode> {
                 router_pattern.as_deref(),
                 *dry_run,
                 *json,
+                *add_js_extension,
             );
         }
         Some(Commands::Watch {
             entrypoint,
             output,
             router_pattern,
+            add_js_extension,
         }) => {
             cli::run_watch(
                 entrypoint.as_deref(),
                 output.as_deref(),
                 router_pattern.as_deref(),
                 cli.verbose > 0,
+                *add_js_extension,
             )?;
         }
         None => {

--- a/packages/nestjs-trpc/cli/src/main.rs
+++ b/packages/nestjs-trpc/cli/src/main.rs
@@ -9,8 +9,8 @@ use tracing::debug;
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::EnvFilter;
 
-use cli::{Cli, Commands, ImportExtensionValue};
-use nestjs_trpc::{config, ParserError, SyntaxDiagnostic};
+use cli::{Cli, Commands};
+use nestjs_trpc::{ParserError, SyntaxDiagnostic};
 
 const EXIT_SUCCESS: u8 = 0;
 const EXIT_RUNTIME_ERROR: u8 = 1;
@@ -101,22 +101,7 @@ fn setup_logging(cli: &Cli) {
     }
 }
 
-fn resolve_import_extension(
-    value: Option<&ImportExtensionValue>,
-    base_directory: &std::path::Path,
-) -> bool {
-    match value {
-        Some(ImportExtensionValue::Js) => true,
-        Some(ImportExtensionValue::None) => false,
-        Some(ImportExtensionValue::Auto) | None => {
-            config::detect_import_extension(base_directory).unwrap_or(false)
-        }
-    }
-}
-
 fn run(cli: &Cli) -> Result<ExitCode> {
-    let current_directory = std::env::current_dir()?;
-
     match &cli.command {
         Some(Commands::Generate {
             entrypoint,
@@ -126,15 +111,13 @@ fn run(cli: &Cli) -> Result<ExitCode> {
             dry_run,
             import_extension,
         }) => {
-            let should_add_js =
-                resolve_import_extension(import_extension.as_ref(), &current_directory);
             return cli::run_generate(
                 entrypoint.as_deref(),
                 output.as_deref(),
                 router_pattern.as_deref(),
                 *dry_run,
                 *json,
-                should_add_js,
+                import_extension.as_ref(),
             );
         }
         Some(Commands::Watch {
@@ -143,14 +126,12 @@ fn run(cli: &Cli) -> Result<ExitCode> {
             router_pattern,
             import_extension,
         }) => {
-            let should_add_js =
-                resolve_import_extension(import_extension.as_ref(), &current_directory);
             cli::run_watch(
                 entrypoint.as_deref(),
                 output.as_deref(),
                 router_pattern.as_deref(),
                 cli.verbose > 0,
-                should_add_js,
+                import_extension.as_ref(),
             )?;
         }
         None => {

--- a/packages/nestjs-trpc/cli/src/main.rs
+++ b/packages/nestjs-trpc/cli/src/main.rs
@@ -9,8 +9,8 @@ use tracing::debug;
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::EnvFilter;
 
-use cli::{Cli, Commands};
-use nestjs_trpc::{ParserError, SyntaxDiagnostic};
+use cli::{Cli, Commands, ImportExtensionValue};
+use nestjs_trpc::{config, ParserError, SyntaxDiagnostic};
 
 const EXIT_SUCCESS: u8 = 0;
 const EXIT_RUNTIME_ERROR: u8 = 1;
@@ -101,7 +101,22 @@ fn setup_logging(cli: &Cli) {
     }
 }
 
+fn resolve_import_extension(
+    value: Option<&ImportExtensionValue>,
+    base_directory: &std::path::Path,
+) -> bool {
+    match value {
+        Some(ImportExtensionValue::Js) => true,
+        Some(ImportExtensionValue::None) => false,
+        Some(ImportExtensionValue::Auto) | None => {
+            config::detect_import_extension(base_directory).unwrap_or(false)
+        }
+    }
+}
+
 fn run(cli: &Cli) -> Result<ExitCode> {
+    let current_directory = std::env::current_dir()?;
+
     match &cli.command {
         Some(Commands::Generate {
             entrypoint,
@@ -109,29 +124,33 @@ fn run(cli: &Cli) -> Result<ExitCode> {
             router_pattern,
             json,
             dry_run,
-            add_js_extension,
+            import_extension,
         }) => {
+            let should_add_js =
+                resolve_import_extension(import_extension.as_ref(), &current_directory);
             return cli::run_generate(
                 entrypoint.as_deref(),
                 output.as_deref(),
                 router_pattern.as_deref(),
                 *dry_run,
                 *json,
-                *add_js_extension,
+                should_add_js,
             );
         }
         Some(Commands::Watch {
             entrypoint,
             output,
             router_pattern,
-            add_js_extension,
+            import_extension,
         }) => {
+            let should_add_js =
+                resolve_import_extension(import_extension.as_ref(), &current_directory);
             cli::run_watch(
                 entrypoint.as_deref(),
                 output.as_deref(),
                 router_pattern.as_deref(),
                 cli.verbose > 0,
-                *add_js_extension,
+                should_add_js,
             )?;
         }
         None => {

--- a/packages/nestjs-trpc/cli/src/tsconfig.rs
+++ b/packages/nestjs-trpc/cli/src/tsconfig.rs
@@ -1,0 +1,610 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+use jsonc_parser::{parse_to_serde_value, ParseOptions};
+use serde_json::{Map, Value};
+use tracing::debug;
+
+/// Resolves `compilerOptions` from a project's tsconfig.json, following
+/// the full `extends` chain exactly like TypeScript.
+///
+/// Returns `None` if no tsconfig.json exists or it cannot be parsed.
+#[must_use]
+pub fn resolve_compiler_options(base_directory: &Path) -> Option<Map<String, Value>> {
+    let tsconfig_path = base_directory.join("tsconfig.json");
+    if !tsconfig_path.is_file() {
+        return None;
+    }
+
+    let mut seen = HashSet::new();
+    resolve_tsconfig_internal(&tsconfig_path, &mut seen)
+}
+
+fn resolve_tsconfig_internal(
+    tsconfig_path: &Path,
+    seen: &mut HashSet<PathBuf>,
+) -> Option<Map<String, Value>> {
+    let canonical = fs::canonicalize(tsconfig_path).ok()?;
+
+    if !seen.insert(canonical.clone()) {
+        debug!("Cyclic extends detected: {}", tsconfig_path.display());
+        return None;
+    }
+
+    let contents = fs::read_to_string(&canonical).ok()?;
+    let parsed: Value = parse_to_serde_value(&contents, &ParseOptions::default())
+        .map_err(|error| {
+            debug!("JSONC parse error in {}: {:?}", canonical.display(), error);
+        })
+        .ok()?;
+
+    let obj = parsed.as_object()?;
+    let tsconfig_directory = canonical.parent()?;
+
+    let child_options = obj
+        .get("compilerOptions")
+        .and_then(|value| value.as_object())
+        .cloned()
+        .unwrap_or_default();
+
+    let extends_value = match obj.get("extends") {
+        Some(Value::String(string)) => Some(string.as_str().to_owned()),
+        Some(Value::Array(array)) => {
+            let merged = merge_extends_array(array, tsconfig_directory, seen);
+            return Some(merge_compiler_options(merged, child_options));
+        }
+        _ => None,
+    };
+
+    let Some(extends_str) = extends_value else {
+        return Some(child_options);
+    };
+
+    let parent_options = resolve_extends_path(&extends_str, tsconfig_directory)
+        .and_then(|parent_path| resolve_tsconfig_internal(&parent_path, seen));
+
+    let Some(options) = parent_options else {
+        debug!(
+            "Unresolvable extends '{}' from {}",
+            extends_str,
+            canonical.display()
+        );
+        return Some(child_options);
+    };
+
+    Some(merge_compiler_options(options, child_options))
+}
+
+fn merge_extends_array(
+    array: &[Value],
+    tsconfig_directory: &Path,
+    seen: &mut HashSet<PathBuf>,
+) -> Map<String, Value> {
+    let mut merged = Map::new();
+    for item in array {
+        let Some(extends_str) = item.as_str() else {
+            continue;
+        };
+        let Some(parent_path) = resolve_extends_path(extends_str, tsconfig_directory) else {
+            continue;
+        };
+        let Some(parent_options) = resolve_tsconfig_internal(&parent_path, seen) else {
+            continue;
+        };
+        merged = merge_compiler_options(parent_options, merged);
+    }
+    merged
+}
+
+fn resolve_extends_path(extends: &str, tsconfig_directory: &Path) -> Option<PathBuf> {
+    let extends_path = Path::new(extends);
+
+    if extends_path.is_absolute() || extends.starts_with('.') || !extends_path.has_root() {
+        return try_resolve_path(tsconfig_directory, extends_path);
+    }
+
+    let (package_name, subpath) = split_package_reference(extends);
+    resolve_package_extends(tsconfig_directory, &package_name, &subpath)
+}
+
+fn try_resolve_path(base_directory: &Path, path: &Path) -> Option<PathBuf> {
+    let resolved = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        base_directory.join(path)
+    };
+
+    let resolved: PathBuf = resolved
+        .components()
+        .filter(|component| !matches!(component, Component::CurDir))
+        .collect();
+
+    if resolved.is_file() {
+        return Some(resolved);
+    }
+
+    let with_json_extension = resolved.with_extension("json");
+    if with_json_extension.is_file() {
+        return Some(with_json_extension);
+    }
+
+    let as_directory = resolved.join("tsconfig.json");
+    if as_directory.is_file() {
+        return Some(as_directory);
+    }
+
+    None
+}
+
+fn split_package_reference(extends: &str) -> (String, String) {
+    if let Some(stripped) = extends.strip_prefix('@') {
+        return split_scoped_package(stripped, extends);
+    }
+
+    let Some(slash_position) = extends.find('/') else {
+        return (extends.to_string(), String::new());
+    };
+
+    let package_name = extends[..slash_position].to_string();
+    let subpath = extends[slash_position + 1..].to_string();
+    (package_name, subpath)
+}
+
+fn split_scoped_package(stripped: &str, full: &str) -> (String, String) {
+    let Some(first_slash) = stripped.find('/') else {
+        return (full.to_string(), String::new());
+    };
+
+    let scope_end = first_slash + 1;
+    let rest = &full[scope_end + 1..];
+
+    let Some(second_slash) = rest.find('/') else {
+        return (full.to_string(), String::new());
+    };
+
+    let package_end = scope_end + second_slash + 1;
+    let package_name = full[..package_end].to_string();
+    let subpath = full[package_end + 1..].to_string();
+    (package_name, subpath)
+}
+
+fn resolve_package_extends(
+    start_directory: &Path,
+    package_name: &str,
+    subpath: &str,
+) -> Option<PathBuf> {
+    let mut current = Some(start_directory.to_path_buf());
+    while let Some(directory) = current.take() {
+        let node_modules = directory.join("node_modules");
+        let package_directory = node_modules.join(package_name);
+
+        if let Some(found) = resolve_in_package(&package_directory, subpath) {
+            return Some(found);
+        }
+
+        current = directory.parent().map(Path::to_path_buf);
+    }
+
+    None
+}
+
+fn resolve_in_package(package_directory: &Path, subpath: &str) -> Option<PathBuf> {
+    if !package_directory.is_dir() {
+        return None;
+    }
+
+    if subpath.is_empty() {
+        let tsconfig_path = package_directory.join("tsconfig.json");
+        return tsconfig_path.is_file().then_some(tsconfig_path);
+    }
+
+    let resolved = package_directory.join(subpath);
+    try_resolve_path(package_directory, &resolved)
+}
+
+fn merge_compiler_options(
+    parent: Map<String, Value>,
+    child: Map<String, Value>,
+) -> Map<String, Value> {
+    let mut merged = parent;
+    for (key, value) in child {
+        merged.insert(key, value);
+    }
+    merged
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_no_tsconfig() {
+        let temporary_directory = TempDir::new().unwrap();
+        let result = resolve_compiler_options(temporary_directory.path());
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_simple_compiler_options() {
+        let temporary_directory = TempDir::new().unwrap();
+        let base = temporary_directory.path();
+
+        let tsconfig = serde_json::json!({
+            "compilerOptions": {
+                "module": "NodeNext",
+                "strict": true
+            }
+        });
+        fs::write(
+            base.join("tsconfig.json"),
+            serde_json::to_string_pretty(&tsconfig).unwrap(),
+        )
+        .unwrap();
+
+        let result = resolve_compiler_options(base).unwrap();
+        assert_eq!(
+            result.get("module").and_then(|v| v.as_str()),
+            Some("NodeNext")
+        );
+        assert_eq!(
+            result.get("strict").and_then(serde_json::Value::as_bool),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn test_jsonc_comments_and_trailing_commas() {
+        let temporary_directory = TempDir::new().unwrap();
+        let base = temporary_directory.path();
+
+        let tsconfig = r#"{
+            // this is a comment
+            "compilerOptions": {
+                "module": "NodeNext",
+                "strict": true, // trailing comma
+            },
+        }"#;
+        fs::write(base.join("tsconfig.json"), tsconfig).unwrap();
+
+        let result = resolve_compiler_options(base).unwrap();
+        assert_eq!(
+            result.get("module").and_then(|v| v.as_str()),
+            Some("NodeNext")
+        );
+    }
+
+    #[test]
+    fn test_extends_inherits_compiler_options() {
+        let temporary_directory = TempDir::new().unwrap();
+        let base = temporary_directory.path();
+
+        let parent = serde_json::json!({
+            "compilerOptions": {
+                "module": "NodeNext",
+                "strict": true
+            }
+        });
+        fs::write(
+            base.join("tsconfig.base.json"),
+            serde_json::to_string_pretty(&parent).unwrap(),
+        )
+        .unwrap();
+
+        let child = serde_json::json!({
+            "extends": "./tsconfig.base.json",
+            "compilerOptions": {
+                "outDir": "./dist"
+            }
+        });
+        fs::write(
+            base.join("tsconfig.json"),
+            serde_json::to_string_pretty(&child).unwrap(),
+        )
+        .unwrap();
+
+        let result = resolve_compiler_options(base).unwrap();
+        assert_eq!(
+            result.get("module").and_then(|v| v.as_str()),
+            Some("NodeNext")
+        );
+        assert_eq!(
+            result.get("strict").and_then(serde_json::Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            result.get("outDir").and_then(|v| v.as_str()),
+            Some("./dist")
+        );
+    }
+
+    #[test]
+    fn test_extends_child_overrides_parent() {
+        let temporary_directory = TempDir::new().unwrap();
+        let base = temporary_directory.path();
+
+        let parent = serde_json::json!({
+            "compilerOptions": {
+                "module": "NodeNext",
+                "strict": true
+            }
+        });
+        fs::write(
+            base.join("tsconfig.base.json"),
+            serde_json::to_string_pretty(&parent).unwrap(),
+        )
+        .unwrap();
+
+        let child = serde_json::json!({
+            "extends": "./tsconfig.base.json",
+            "compilerOptions": {
+                "module": "ESNext",
+                "strict": false
+            }
+        });
+        fs::write(
+            base.join("tsconfig.json"),
+            serde_json::to_string_pretty(&child).unwrap(),
+        )
+        .unwrap();
+
+        let result = resolve_compiler_options(base).unwrap();
+        assert_eq!(
+            result.get("module").and_then(|v| v.as_str()),
+            Some("ESNext")
+        );
+        assert_eq!(
+            result.get("strict").and_then(serde_json::Value::as_bool),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn test_extends_three_level_chain() {
+        let temporary_directory = TempDir::new().unwrap();
+        let base = temporary_directory.path();
+
+        let grandparent = serde_json::json!({
+            "compilerOptions": {
+                "target": "ES2020"
+            }
+        });
+        fs::write(
+            base.join("tsconfig.base.json"),
+            serde_json::to_string_pretty(&grandparent).unwrap(),
+        )
+        .unwrap();
+
+        let parent = serde_json::json!({
+            "extends": "./tsconfig.base.json",
+            "compilerOptions": {
+                "module": "NodeNext"
+            }
+        });
+        fs::write(
+            base.join("tsconfig.project.json"),
+            serde_json::to_string_pretty(&parent).unwrap(),
+        )
+        .unwrap();
+
+        let child = serde_json::json!({
+            "extends": "./tsconfig.project.json",
+            "compilerOptions": {
+                "outDir": "./dist"
+            }
+        });
+        fs::write(
+            base.join("tsconfig.json"),
+            serde_json::to_string_pretty(&child).unwrap(),
+        )
+        .unwrap();
+
+        let result = resolve_compiler_options(base).unwrap();
+        assert_eq!(
+            result.get("target").and_then(|v| v.as_str()),
+            Some("ES2020")
+        );
+        assert_eq!(
+            result.get("module").and_then(|v| v.as_str()),
+            Some("NodeNext")
+        );
+        assert_eq!(
+            result.get("outDir").and_then(|v| v.as_str()),
+            Some("./dist")
+        );
+    }
+
+    #[test]
+    fn test_cyclic_extends_does_not_loop() {
+        let temporary_directory = TempDir::new().unwrap();
+        let base = temporary_directory.path();
+
+        let a = serde_json::json!({
+            "extends": "./tsconfig.b.json",
+            "compilerOptions": {
+                "module": "NodeNext"
+            }
+        });
+        fs::write(
+            base.join("tsconfig.a.json"),
+            serde_json::to_string_pretty(&a).unwrap(),
+        )
+        .unwrap();
+
+        let b = serde_json::json!({
+            "extends": "./tsconfig.a.json",
+            "compilerOptions": {
+                "moduleResolution": "NodeNext"
+            }
+        });
+        fs::write(
+            base.join("tsconfig.b.json"),
+            serde_json::to_string_pretty(&b).unwrap(),
+        )
+        .unwrap();
+
+        let main = serde_json::json!({
+            "extends": "./tsconfig.a.json",
+            "compilerOptions": {}
+        });
+        fs::write(
+            base.join("tsconfig.json"),
+            serde_json::to_string_pretty(&main).unwrap(),
+        )
+        .unwrap();
+
+        let result = resolve_compiler_options(base).unwrap();
+        assert_eq!(
+            result.get("module").and_then(|v| v.as_str()),
+            Some("NodeNext")
+        );
+        assert_eq!(
+            result.get("moduleResolution").and_then(|v| v.as_str()),
+            Some("NodeNext")
+        );
+    }
+
+    #[test]
+    fn test_extends_array_type_script_5_plus() {
+        let temporary_directory = TempDir::new().unwrap();
+        let base = temporary_directory.path();
+
+        let common = serde_json::json!({
+            "compilerOptions": {
+                "strict": true,
+                "target": "ES2020"
+            }
+        });
+        fs::write(
+            base.join("tsconfig.common.json"),
+            serde_json::to_string_pretty(&common).unwrap(),
+        )
+        .unwrap();
+
+        let node = serde_json::json!({
+            "compilerOptions": {
+                "module": "NodeNext",
+                "moduleResolution": "NodeNext"
+            }
+        });
+        fs::write(
+            base.join("tsconfig.node.json"),
+            serde_json::to_string_pretty(&node).unwrap(),
+        )
+        .unwrap();
+
+        let main = serde_json::json!({
+            "extends": ["./tsconfig.common.json", "./tsconfig.node.json"],
+            "compilerOptions": {
+                "outDir": "./dist"
+            }
+        });
+        fs::write(
+            base.join("tsconfig.json"),
+            serde_json::to_string_pretty(&main).unwrap(),
+        )
+        .unwrap();
+
+        let result = resolve_compiler_options(base).unwrap();
+        assert_eq!(
+            result.get("strict").and_then(serde_json::Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            result.get("target").and_then(|v| v.as_str()),
+            Some("ES2020")
+        );
+        assert_eq!(
+            result.get("module").and_then(|v| v.as_str()),
+            Some("NodeNext")
+        );
+        assert_eq!(
+            result.get("outDir").and_then(|v| v.as_str()),
+            Some("./dist")
+        );
+    }
+
+    #[test]
+    fn test_relative_extends_without_extension() {
+        let temporary_directory = TempDir::new().unwrap();
+        let base = temporary_directory.path();
+
+        let parent = serde_json::json!({
+            "compilerOptions": {
+                "module": "NodeNext"
+            }
+        });
+        // Without .json extension in filename
+        fs::write(
+            base.join("base.json"),
+            serde_json::to_string_pretty(&parent).unwrap(),
+        )
+        .unwrap();
+
+        let child = serde_json::json!({
+            "extends": "./base",
+            "compilerOptions": {
+                "outDir": "./dist"
+            }
+        });
+        fs::write(
+            base.join("tsconfig.json"),
+            serde_json::to_string_pretty(&child).unwrap(),
+        )
+        .unwrap();
+
+        let result = resolve_compiler_options(base).unwrap();
+        assert_eq!(
+            result.get("module").and_then(|v| v.as_str()),
+            Some("NodeNext")
+        );
+    }
+
+    #[test]
+    fn test_missing_extends_falls_back_to_own_options() {
+        let temporary_directory = TempDir::new().unwrap();
+        let base = temporary_directory.path();
+
+        let child = serde_json::json!({
+            "extends": "./nonexistent.json",
+            "compilerOptions": {
+                "module": "ESNext"
+            }
+        });
+        fs::write(
+            base.join("tsconfig.json"),
+            serde_json::to_string_pretty(&child).unwrap(),
+        )
+        .unwrap();
+
+        let result = resolve_compiler_options(base).unwrap();
+        assert_eq!(
+            result.get("module").and_then(|v| v.as_str()),
+            Some("ESNext")
+        );
+    }
+
+    #[test]
+    fn test_empty_tsconfig() {
+        let temporary_directory = TempDir::new().unwrap();
+        let base = temporary_directory.path();
+
+        fs::write(base.join("tsconfig.json"), "{}").unwrap();
+
+        let result = resolve_compiler_options(base);
+        assert!(result.is_some());
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_invalid_jsonc_recovers() {
+        let temporary_directory = TempDir::new().unwrap();
+        let base = temporary_directory.path();
+
+        fs::write(base.join("tsconfig.json"), "not valid").unwrap();
+
+        let result = resolve_compiler_options(base);
+        assert_eq!(result, None);
+    }
+}

--- a/packages/nestjs-trpc/cli/src/tsconfig.rs
+++ b/packages/nestjs-trpc/cli/src/tsconfig.rs
@@ -6,19 +6,26 @@ use jsonc_parser::{parse_to_serde_value, ParseOptions};
 use serde_json::{Map, Value};
 use tracing::debug;
 
-/// Resolves `compilerOptions` from a project's tsconfig.json, following
+/// Resolves `compilerOptions` from the nearest `tsconfig.json`, following
 /// the full `extends` chain exactly like TypeScript.
 ///
-/// Returns `None` if no tsconfig.json exists or it cannot be parsed.
+/// Walks upward from `start_directory` through ancestor directories until a
+/// `tsconfig.json` is found, mirroring the way `tsc` discovers its config.
+///
+/// Returns `None` if no `tsconfig.json` exists anywhere in the tree or it
+/// cannot be parsed.
 #[must_use]
-pub fn resolve_compiler_options(base_directory: &Path) -> Option<Map<String, Value>> {
-    let tsconfig_path = base_directory.join("tsconfig.json");
-    if !tsconfig_path.is_file() {
-        return None;
+pub fn resolve_compiler_options(start_directory: &Path) -> Option<Map<String, Value>> {
+    let mut current = Some(start_directory.to_path_buf());
+    while let Some(dir) = current.take() {
+        let tsconfig_path = dir.join("tsconfig.json");
+        if tsconfig_path.is_file() {
+            let mut seen = HashSet::new();
+            return resolve_tsconfig_internal(&tsconfig_path, &mut seen);
+        }
+        current = dir.parent().map(Path::to_path_buf);
     }
-
-    let mut seen = HashSet::new();
-    resolve_tsconfig_internal(&tsconfig_path, &mut seen)
+    None
 }
 
 fn resolve_tsconfig_internal(
@@ -223,6 +230,74 @@ mod tests {
     fn test_no_tsconfig() {
         let temporary_directory = TempDir::new().unwrap();
         let result = resolve_compiler_options(temporary_directory.path());
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_tsconfig_in_parent_directory() {
+        let temporary_directory = TempDir::new().unwrap();
+        let root = temporary_directory.path();
+
+        // tsconfig lives at the root, not inside `src/`.
+        let tsconfig = serde_json::json!({
+            "compilerOptions": {
+                "module": "NodeNext"
+            }
+        });
+        fs::write(
+            root.join("tsconfig.json"),
+            serde_json::to_string_pretty(&tsconfig).unwrap(),
+        )
+        .unwrap();
+
+        // Start search from the child directory — should walk up and find it.
+        let src = root.join("src");
+        fs::create_dir_all(&src).unwrap();
+
+        let result = resolve_compiler_options(&src).unwrap();
+        assert_eq!(
+            result.get("module").and_then(|v| v.as_str()),
+            Some("NodeNext")
+        );
+    }
+
+    #[test]
+    fn test_tsconfig_found_in_grandparent() {
+        let temporary_directory = TempDir::new().unwrap();
+        let root = temporary_directory.path();
+
+        let tsconfig = serde_json::json!({
+            "compilerOptions": {
+                "module": "Node16"
+            }
+        });
+        fs::write(
+            root.join("tsconfig.json"),
+            serde_json::to_string_pretty(&tsconfig).unwrap(),
+        )
+        .unwrap();
+
+        // Two levels deep — no tsconfig at either intermediate level.
+        let nested = root.join("a").join("b");
+        fs::create_dir_all(&nested).unwrap();
+
+        let result = resolve_compiler_options(&nested).unwrap();
+        assert_eq!(
+            result.get("module").and_then(|v| v.as_str()),
+            Some("Node16")
+        );
+    }
+
+    #[test]
+    fn test_no_tsconfig_anywhere_returns_none() {
+        let temporary_directory = TempDir::new().unwrap();
+        let root = temporary_directory.path();
+
+        // No tsconfig anywhere in the tree.
+        let nested = root.join("deep").join("nesting");
+        fs::create_dir_all(&nested).unwrap();
+
+        let result = resolve_compiler_options(&nested);
         assert_eq!(result, None);
     }
 

--- a/packages/nestjs-trpc/cli/src/validation/tsc.rs
+++ b/packages/nestjs-trpc/cli/src/validation/tsc.rs
@@ -53,26 +53,30 @@ pub fn find_tsc(base_directory: &Path) -> Option<PathBuf> {
     find_tsc_in_path()
 }
 
-fn find_tsc_in_path() -> Option<PathBuf> {
-    let path_var = std::env::var("PATH").ok()?;
-    let separator = if cfg!(windows) { ';' } else { ':' };
+fn find_tsc_executable_in_directory(directory: &str) -> Option<PathBuf> {
+    let tsc_path = Path::new(directory).join("tsc");
+    if tsc_path.exists() {
+        return Some(tsc_path);
+    }
 
-    for directory in path_var.split(separator) {
-        let tsc_path = Path::new(directory).join("tsc");
-        if tsc_path.exists() {
-            return Some(tsc_path);
-        }
-
-        #[cfg(windows)]
-        {
-            let tsc_cmd = Path::new(directory).join("tsc.cmd");
-            if tsc_cmd.exists() {
-                return Some(tsc_cmd);
-            }
+    #[cfg(windows)]
+    {
+        let windows_tsc_path = Path::new(directory).join("tsc.cmd");
+        if windows_tsc_path.exists() {
+            return Some(windows_tsc_path);
         }
     }
 
     None
+}
+
+fn find_tsc_in_path() -> Option<PathBuf> {
+    let path_variable = std::env::var("PATH").ok()?;
+    let separator = if cfg!(windows) { ';' } else { ':' };
+
+    path_variable
+        .split(separator)
+        .find_map(find_tsc_executable_in_directory)
 }
 
 #[allow(clippy::expect_used)]

--- a/packages/nestjs-trpc/cli/src/watcher/mod.rs
+++ b/packages/nestjs-trpc/cli/src/watcher/mod.rs
@@ -36,7 +36,7 @@ pub struct WatchConfig {
     pub transformer: Option<TransformerInfo>,
 
     /// Add .js extension to local import paths for ESM compatibility
-    pub add_js_extension: bool,
+    pub import_extension: bool,
 }
 
 impl WatchConfig {
@@ -54,7 +54,7 @@ impl WatchConfig {
             debounce_milliseconds: DEFAULT_DEBOUNCE_MILLISECONDS,
             verbose: false,
             transformer: None,
-            add_js_extension: false,
+            import_extension: false,
         }
     }
 
@@ -81,8 +81,8 @@ impl WatchConfig {
 
     /// Sets whether to add .js extension to local import paths.
     #[must_use]
-    pub const fn with_add_js_extension(mut self, add_js_extension: bool) -> Self {
-        self.add_js_extension = add_js_extension;
+    pub const fn with_import_extension(mut self, import_extension: bool) -> Self {
+        self.import_extension = import_extension;
         self
     }
 }
@@ -156,7 +156,7 @@ impl WatchSession {
             &self.config.output_directory,
             &self.config.router_pattern,
             self.config.transformer.as_ref(),
-            self.config.add_js_extension,
+            self.config.import_extension,
         )
     }
 
@@ -195,7 +195,7 @@ fn handle_file_change(config: &WatchConfig) -> Result<()> {
             &config.output_directory,
             &config.router_pattern,
             config.transformer.as_ref(),
-            config.add_js_extension,
+            config.import_extension,
         )
     });
 

--- a/packages/nestjs-trpc/cli/src/watcher/mod.rs
+++ b/packages/nestjs-trpc/cli/src/watcher/mod.rs
@@ -34,6 +34,9 @@ pub struct WatchConfig {
 
     /// Transformer info extracted from `TRPCModule.forRoot()`
     pub transformer: Option<TransformerInfo>,
+
+    /// Add .js extension to local import paths for ESM compatibility
+    pub add_js_extension: bool,
 }
 
 impl WatchConfig {
@@ -51,6 +54,7 @@ impl WatchConfig {
             debounce_milliseconds: DEFAULT_DEBOUNCE_MILLISECONDS,
             verbose: false,
             transformer: None,
+            add_js_extension: false,
         }
     }
 
@@ -72,6 +76,13 @@ impl WatchConfig {
     #[must_use]
     pub const fn with_verbose(mut self, verbose: bool) -> Self {
         self.verbose = verbose;
+        self
+    }
+
+    /// Sets whether to add .js extension to local import paths.
+    #[must_use]
+    pub const fn with_add_js_extension(mut self, add_js_extension: bool) -> Self {
+        self.add_js_extension = add_js_extension;
         self
     }
 }
@@ -145,6 +156,7 @@ impl WatchSession {
             &self.config.output_directory,
             &self.config.router_pattern,
             self.config.transformer.as_ref(),
+            self.config.add_js_extension,
         )
     }
 
@@ -183,6 +195,7 @@ fn handle_file_change(config: &WatchConfig) -> Result<()> {
             &config.output_directory,
             &config.router_pattern,
             config.transformer.as_ref(),
+            config.add_js_extension,
         )
     });
 

--- a/packages/nestjs-trpc/cli/tests/cli.rs
+++ b/packages/nestjs-trpc/cli/tests/cli.rs
@@ -107,6 +107,52 @@ fn generate_help_shows_subcommand_options() {
 }
 
 #[test]
+fn import_extension_flag_shows_in_help() {
+    cli_command()
+        .arg("generate")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--import-extension"));
+}
+
+#[test]
+fn import_extension_js_is_accepted() {
+    let output_directory = TempDir::new().unwrap();
+    let fixture = fixtures_directory().join("valid/simple-router");
+
+    cli_command()
+        .arg("generate")
+        .arg("--entrypoint")
+        .arg(fixture.join("user.router.ts"))
+        .arg("--output")
+        .arg(output_directory.path())
+        .arg("--import-extension")
+        .arg("js")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Generated server.ts successfully"));
+}
+
+#[test]
+fn import_extension_none_is_accepted() {
+    let output_directory = TempDir::new().unwrap();
+    let fixture = fixtures_directory().join("valid/simple-router");
+
+    cli_command()
+        .arg("generate")
+        .arg("--entrypoint")
+        .arg(fixture.join("user.router.ts"))
+        .arg("--output")
+        .arg(output_directory.path())
+        .arg("--import-extension")
+        .arg("none")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Generated server.ts successfully"));
+}
+
+#[test]
 fn multiple_verbose_flags_accepted() {
     cli_command().arg("-vvv").arg("--help").assert().success();
 }

--- a/packages/nestjs-trpc/cli/tests/generation.rs
+++ b/packages/nestjs-trpc/cli/tests/generation.rs
@@ -18,7 +18,8 @@ fn run_generation_on_fixture(fixture_name: &str) -> String {
     let temporary_directory = TempDir::new().expect("Failed to create temp directory");
     let output_path = temporary_directory.path();
 
-    run_generation(&fixture_path, output_path, "**/*.router.ts", None).expect("Generation failed");
+    run_generation(&fixture_path, output_path, "**/*.router.ts", None, false)
+        .expect("Generation failed");
 
     let server_file = output_path.join("server.ts");
     let content = fs::read_to_string(&server_file).expect("Failed to read generated server.ts");
@@ -142,6 +143,7 @@ fn snapshot_with_default_transformer() {
         output_path,
         "**/*.router.ts",
         Some(&transformer),
+        false,
     )
     .expect("Generation failed");
 
@@ -170,6 +172,7 @@ fn snapshot_with_named_transformer() {
         output_path,
         "**/*.router.ts",
         Some(&transformer),
+        false,
     )
     .expect("Generation failed");
 
@@ -207,6 +210,7 @@ fn run_generation_with_module_transformer(fixture_name: &str) -> String {
         output_path,
         "**/*.router.ts",
         transformer.as_ref(),
+        false,
     )
     .expect("Generation failed");
 

--- a/packages/nestjs-trpc/cli/tests/validation.rs
+++ b/packages/nestjs-trpc/cli/tests/validation.rs
@@ -331,7 +331,8 @@ fn generate_and_validate_typescript(fixture_name: &str) {
     let temporary_directory = TempDir::new().expect("Failed to create temp directory");
     let output_path = temporary_directory.path();
 
-    run_generation(&fixture_path, output_path, "**/*.router.ts", None).expect("Generation failed");
+    run_generation(&fixture_path, output_path, "**/*.router.ts", None, false)
+        .expect("Generation failed");
 
     let server_file = output_path.join("server.ts");
     let generated_content = fs::read_to_string(&server_file).expect("Failed to read server.ts");

--- a/packages/nestjs-trpc/tsconfig.spec.json
+++ b/packages/nestjs-trpc/tsconfig.spec.json
@@ -4,7 +4,7 @@
     "experimentalDecorators": true,
     "sourceMap": true,
     "outDir": "./dist/tests",
-    "types": ["jest", "node"],
+    "types": ["jest", "node", "reflect-metadata"],
     "emitDecoratorMetadata": true
   }
 }


### PR DESCRIPTION
## Summary

Adds full ESM (`"type": "module"`) support to the test suite by fixing type declarations in `tsconfig.spec.json`, enabling compatibility with Node.js ESM resolution and the upcoming NestJS 12 release.
( --add-js-extension  Add .js extension to local import paths for ESM compatibility ).

 Maybe we can use another flag ^_^ --esm ? --nest-esm ?

## Other Changes

- Added `"reflect-metadata"` to the `types` array in `packages/nestjs-trpc/tsconfig.spec.json`
- This ensures `Reflect.getMetadata` / `Reflect.defineMetadata` type declarations from the `reflect-metadata` package are included during ts-jest compilation with `--coverage`
- Previously, 3 decorator test suites failed with `TS2339` errors under coverage mode because the `types` restriction (`["jest", "node"]`) excluded `reflect-metadata` augmentations

## Why

NestJS 12 moves toward full ESM support. I`m using custom scripts to achieve similar behavior of this PR goal, but runs after generation, its not idoneous. See (not important just for reference of the workround for esm support without flag --add-js-extension)
https://github.com/Angel-Mario/nest-auth-trpc-rest-swagger-single/blob/master/src/libs/trpc/scripts/fix-trpc-generated.mjs
https://github.com/Angel-Mario/nest-auth-trpc-rest-swagger-single/blob/master/src/libs/trpc/scripts/watch-trpc.mjs

Running tests with `--add-js-extension` (required for  ESM compatibility) triggers stricter type checking in ts-jest, which exposed this missing type declaration. Fixing it ensures the test suite works correctly in both CommonJS and ESM (`"type": "module"`) environments.

## Test Results

All 17 test suites pass, 78/78 tests green with full coverage.

## Help changes

<img width="1029" height="311" alt="help-info-after-changes" src="https://github.com/user-attachments/assets/a8cb2519-861f-4a42-b7f0-af4a0b268d01" />

## Battle-tested with the build package after changes against this nestjs 12 project:

https://github.com/Angel-Mario/nest-auth-trpc-rest-swagger-single