### PR TITLE
feat: Add sse and jsonl options to TRPCModule.forRoot

### DIFF
--- a/docs/pages/docs/subscriptions.mdx
+++ b/docs/pages/docs/subscriptions.mdx
@@ -118,6 +118,39 @@ async *onMessage(
 }
 ```
 
+#### Keep-Alive Pings
+
+Proxies and load balancers (nginx, AWS ALB, Cloudflare) often close idle HTTP connections after a short timeout.
+Since a subscription stream can stay silent between events, this surfaces as subscriptions that connect successfully but drop after a while and reconnect in a loop.
+
+tRPC can send keep-alive ping comments over the stream to prevent this. Configure it with the `sse` option in `TRPCModule.forRoot(){:tsx}`:
+
+```typescript filename="app.module.ts" copy
+import { Module } from '@nestjs/common';
+import { TRPCModule } from 'nestjs-trpc';
+
+@Module({
+  imports: [
+    TRPCModule.forRoot({
+      sse: {
+        ping: { enabled: true, intervalMs: 30000 },
+        client: { reconnectAfterInactivityMs: 60000 },
+      },
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+Pings are handled at the protocol level — they never reach your subscription's `onData` handler.
+The `client.reconnectAfterInactivityMs` option is sent to the client on connect, so it proactively reconnects whenever the server has been silent for that long.
+
+Streamed batch responses have the same idle-connection failure mode — use the `jsonl.pingMs` option in `TRPCModule.forRoot(){:tsx}` to send keep-alive pings on `httpBatchStreamLink` streams.
+
+<Callout emoji={<TrpcIcon width={25} height={50} className="m-1"/>}>
+  You can read more about server pings and the SSE options in the official <Link href={"https://trpc.io/docs/client/links/httpSubscriptionLink#server-ping"} target="blank" className="underline">httpSubscriptionLink documentation</Link>.
+</Callout>
+
 #### Input Validation
 
 Subscription input is validated the same way as queries and mutations — pass a Zod schema to the `input` option:

--- a/packages/nestjs-trpc/cli/src/generator/server.rs
+++ b/packages/nestjs-trpc/cli/src/generator/server.rs
@@ -727,8 +727,8 @@ mod tests {
         assert!(output.contains("createUser: publicProcedure"));
         assert!(output.contains("updateUser: publicProcedure"));
         // Check procedures are separated by commas
-        assert!(output.matches(".query(async () =>").count() == 1);
-        assert!(output.matches(".mutation(async () =>").count() == 2);
+        assert_eq!(output.matches(".query(async () =>").count(), 1);
+        assert_eq!(output.matches(".mutation(async () =>").count(), 2);
     }
 
     #[test]

--- a/packages/nestjs-trpc/lib/interfaces/index.ts
+++ b/packages/nestjs-trpc/lib/interfaces/index.ts
@@ -3,5 +3,6 @@ export * from './error-handler.interface';
 export * from './middleware.interface';
 export * from './factory.interface';
 export * from './module-options.interface';
+export * from './streaming-options.interface';
 export * from './parser.interface';
 export * from './procedure-options.interface';

--- a/packages/nestjs-trpc/lib/interfaces/module-options.interface.ts
+++ b/packages/nestjs-trpc/lib/interfaces/module-options.interface.ts
@@ -9,6 +9,10 @@ import { TRPCContext } from './context.interface';
 import type { TRPCErrorHandler } from './error-handler.interface';
 import type { TRPCMiddleware } from './middleware.interface';
 import type { Class, Constructor } from 'type-fest';
+import type {
+  TRPCSSEOptions,
+  TRPCJSONLOptions,
+} from './streaming-options.interface';
 
 export interface TRPCModuleOptions {
   basePath?: string;
@@ -49,4 +53,18 @@ export interface TRPCModuleOptions {
   globalMiddlewares?: Array<
     Class<TRPCMiddleware> | Constructor<TRPCMiddleware>
   >;
+
+  /**
+   * Options for server-sent events (SSE) subscriptions, e.g. keep-alive
+   * pings that prevent proxies from closing idle subscription streams.
+   * @link https://trpc.io/docs/server/subscriptions
+   */
+  sse?: TRPCSSEOptions;
+
+  /**
+   * Options for streamed batch responses (`httpBatchStreamLink`), e.g.
+   * keep-alive pings that prevent proxies from closing idle streams.
+   * @link https://trpc.io/docs/client/links/httpBatchStreamLink
+   */
+  jsonl?: TRPCJSONLOptions;
 }

--- a/packages/nestjs-trpc/lib/interfaces/streaming-options.interface.ts
+++ b/packages/nestjs-trpc/lib/interfaces/streaming-options.interface.ts
@@ -1,0 +1,54 @@
+export interface TRPCSSEOptions {
+  /**
+   * Enable server-sent events (SSE) subscriptions
+   * @default true
+   */
+  enabled?: boolean;
+  /**
+   * Keep-alive ping comments sent from the server, preventing proxies
+   * from closing idle subscription streams
+   */
+  ping?: {
+    /**
+     * Enable ping comments sent from the server
+     * @default false
+     */
+    enabled: boolean;
+    /**
+     * Interval in milliseconds
+     * @default 1000
+     */
+    intervalMs?: number;
+  };
+  /**
+   * Maximum duration in milliseconds for the request before ending the stream
+   * @default undefined
+   */
+  maxDurationMs?: number;
+  /**
+   * End the request immediately after data is sent
+   * Only useful for serverless runtimes that do not support streaming responses
+   * @default false
+   */
+  emitAndEndImmediately?: boolean;
+  /**
+   * Client-specific options - these will be sent to the client as part of the first message
+   * @default {}
+   */
+  client?: {
+    /**
+     * Timeout and reconnect after inactivity in milliseconds
+     * @default undefined
+     */
+    reconnectAfterInactivityMs?: number;
+  };
+}
+
+export interface TRPCJSONLOptions {
+  /**
+   * Interval in milliseconds between keep-alive pings on streamed batch
+   * responses (`httpBatchStreamLink`)
+   * @default undefined
+   */
+  pingMs?: number;
+}

--- a/packages/nestjs-trpc/lib/trpc.driver.ts
+++ b/packages/nestjs-trpc/lib/trpc.driver.ts
@@ -60,6 +60,8 @@ export class TRPCDriver<
       ...(options.errorFormatter != null
         ? { errorFormatter: options.errorFormatter }
         : {}),
+      ...(options.sse != null ? { sse: options.sse } : {}),
+      ...(options.jsonl != null ? { jsonl: options.jsonl } : {}),
     });
 
     const procedure = this.applyGlobalMiddlewares(


### PR DESCRIPTION
## Motivation

`TRPCDriver.start()` currently forwards only `transformer` and `errorFormatter` to `initTRPC.create()`, so tRPC's `sse` and `jsonl` runtime options cannot be configured through `TRPCModule.forRoot()`.

The practical consequence: SSE subscriptions send nothing between events, and any proxy in front of the app (nginx, AWS ALB, Cloudflare, dokku/Heroku-style routers) closes the idle stream after its read timeout — typically 60s. Clients then live in a connect → idle → drop → reconnect loop. tRPC's built-in fix is server keep-alive pings (https://trpc.io/docs/client/links/httpSubscriptionLink#server-ping), but there is currently no way to switch them on through this adapter. `jsonl.pingMs` is the same keep-alive story for `httpBatchStreamLink` streamed responses.

## Changes

- Added `sse` and `jsonl` options to `TRPCModuleOptions`, typed by new `TRPCSSEOptions` / `TRPCJSONLOptions` interfaces in `interfaces/streaming-options.interface.ts` (structurally matching tRPC's root config fields, following the pattern of `error-handler.interface.ts`).
- `TRPCDriver.start()` forwards both to `initTRPC.create()` when provided, same `!= null` spread style as the existing options.
- Documented a "Keep-Alive Pings" section on the subscriptions docs page.

Usage:

```typescript
TRPCModule.forRoot({
  sse: {
    ping: { enabled: true, intervalMs: 30000 },
    client: { reconnectAfterInactivityMs: 60000 },
  },
  jsonl: { pingMs: 30000 },
})
```

No behavior change when the options are omitted. The remaining `initTRPC.create()` options (`isDev`, `defaultMeta`, `allowOutsideOfServer`, `isServer`) are intentionally left out to keep this focused on the two options that fix production breakage — happy to add them here or in a follow-up if you'd like full runtime-config passthrough.

`bun run build`, `bun run lint`, and the test suite (78 tests, 17 suites) pass.